### PR TITLE
GitHub Provider

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -86,6 +86,8 @@ jobs:
         env:
           AZDO_PAT: ${{ secrets.AZDO_PAT }}
           AZDO_URL: ${{ secrets.AZDO_URL }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_URL: ${{ secrets.GH_URL }}
         run: |
           make cover
       - name: Send coverage to coverall

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test: fmt vet
 
 cover:
 	mkdir -p tmp
-	go test -timeout 2m -coverpkg=./... -coverprofile=tmp/coverage.out ./...
+	go test -timeout 5m -coverpkg=./... -coverprofile=tmp/coverage.out ./...
 	go tool cover -html=tmp/coverage.out
 
 docker-build:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # GitOps Promotion
 
 A tool to do automatic promotion with a GitOps workflow.
+
+## Building
+
+You will need pkg-config and libgit2, please install it from your package manager.
+
+## Testing the GitHub provider
+
+The test suite for the GitHub provider requires access to an actual GitHub repository. In order to run these tests, create an empty repository and set up an access key and invoke the tests like so:
+
+env GITHUB_URL='' GITHUB_TOKEN='' go test ./...
+
+The GitHub Action CI runs the tests against https://github.com/gitops-promotion/gitops-promotion-testing.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/andybalholm/brotli v1.0.2 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/fluxcd/image-automation-controller v0.14.1
 	github.com/fluxcd/image-reflector-controller/api v0.10.0
 	github.com/fluxcd/source-controller v0.15.4
@@ -18,16 +19,16 @@ require (
 	github.com/google/go-containerregistry v0.5.0 // indirect
 	github.com/google/go-github/v37 v37.0.0
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.2.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/jfrog/jfrog-client-go v0.26.1
 	github.com/klauspost/compress v1.12.2 // indirect
 	github.com/libgit2/git2go/v31 v31.4.14
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/onsi/ginkgo v1.16.4
-	github.com/onsi/gomega v1.13.0
+	github.com/onsi/gomega v1.14.0
 	github.com/pierrec/lz4/v4 v4.1.6 // indirect
-	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-openapi/validate v0.20.2 // indirect
 	github.com/google/go-containerregistry v0.5.0 // indirect
+	github.com/google/go-github/v35 v35.3.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/jfrog/jfrog-client-go v0.26.1
@@ -23,11 +24,14 @@ require (
 	github.com/libgit2/git2go/v31 v31.4.14
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
+	github.com/onsi/ginkgo v1.16.4
+	github.com/onsi/gomega v1.13.0
 	github.com/pierrec/lz4/v4 v4.1.6 // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/whilp/git-urls v1.0.0
 	github.com/xlab/treeprint v1.1.0 // indirect
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/term v0.0.0-20210429154555-c04ba851c2a4 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.21.3

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-openapi/validate v0.20.2 // indirect
 	github.com/google/go-containerregistry v0.5.0 // indirect
-	github.com/google/go-github/v35 v35.3.0
+	github.com/google/go-github/v37 v37.0.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/jfrog/jfrog-client-go v0.26.1

--- a/go.mod
+++ b/go.mod
@@ -27,10 +27,13 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
 	github.com/pierrec/lz4/v4 v4.1.6 // indirect
+	github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 // indirect
+	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
 	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	github.com/whilp/git-urls v1.0.0
 	github.com/xlab/treeprint v1.1.0 // indirect
+	golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/term v0.0.0-20210429154555-c04ba851c2a4 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -646,8 +646,8 @@ github.com/google/go-containerregistry v0.1.1/go.mod h1:npTSyywOeILcgWqd+rvtzGWf
 github.com/google/go-containerregistry v0.5.0 h1:eb9sinv4PKm0AUwQGov0mvIdA4pyBGjRofxN4tWnMwM=
 github.com/google/go-containerregistry v0.5.0/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
-github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
-github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
+github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
+github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,8 @@ github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:o
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
@@ -1427,7 +1429,6 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/go.sum
+++ b/go.sum
@@ -600,6 +600,7 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -638,12 +639,16 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.1.1/go.mod h1:npTSyywOeILcgWqd+rvtzGWflIPPcBQhYoOONaY4ltM=
 github.com/google/go-containerregistry v0.5.0 h1:eb9sinv4PKm0AUwQGov0mvIdA4pyBGjRofxN4tWnMwM=
 github.com/google/go-containerregistry v0.5.0/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
+github.com/google/go-github/v35 v35.3.0 h1:fU+WBzuukn0VssbayTT+Zo3/ESKX9JYWjbZTLOTEyho=
+github.com/google/go-github/v35 v35.3.0/go.mod h1:yWB7uCcVWaUbUP74Aq3whuMySRMatyRmq5U9FTNlbio=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
@@ -1426,6 +1431,7 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1666,6 +1672,7 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/cloud v0.0.0-20151119220103-975617b05ea8/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -1725,6 +1732,7 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/go.sum
+++ b/go.sum
@@ -1119,8 +1119,12 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228 h1:N5B+JgvM/DVYIxreItPJMM3yWrNO/GB2q4nESrtBisM=
+github.com/shurcooL/githubv4 v0.0.0-20210725200734-83ba7b4c9228/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a h1:KikTa6HtAK8cS1qjvUvvq4QO21QnwC+EfvB+OAuZ/ZU=
+github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -1425,6 +1429,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
+golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/main.go
+++ b/main.go
@@ -33,14 +33,17 @@ func run(args []string) (string, error) {
 	newApp := newCommand.String("app", "", "stage the pipeline is currently in")
 	newTag := newCommand.String("tag", "", "stage the pipeline is currently in")
 	newPath := newCommand.String("sourcedir", defaultPath, "Source working tree to operate on")
+	newProviderType := newCommand.String("provider", "azdo", "git provider to use")
 
 	promoteCommand := flag.NewFlagSet("promote", flag.ExitOnError)
 	promoteToken := promoteCommand.String("token", "", "stage the pipeline is currently in")
 	promotePath := promoteCommand.String("sourcedir", defaultPath, "Source working tree to operate on")
+	promoteProviderType := promoteCommand.String("provider", "azdo", "git provider to use")
 
 	statusCommand := flag.NewFlagSet("status", flag.ExitOnError)
 	statusToken := statusCommand.String("token", "", "stage the pipeline is currently in")
 	statusPath := statusCommand.String("sourcedir", defaultPath, "Source working tree to operate on")
+	statusProviderType := statusCommand.String("provider", "azdo", "git provider to use")
 
 	if len(args) < 2 {
 		return "", fmt.Errorf("new, promote or status subcommand is required")
@@ -57,7 +60,7 @@ func run(args []string) (string, error) {
 			return "", err
 		}
 		message, commandErr = withCopyOfWorkTree(newPath, func(workTreeCopy string) (string, error) {
-			return command.NewCommand(ctx, workTreeCopy, *newToken, *newGroup, *newApp, *newTag)
+			return command.NewCommand(ctx, *newProviderType, workTreeCopy, *newToken, *newGroup, *newApp, *newTag)
 		})
 	case "promote":
 		err := promoteCommand.Parse(args[2:])
@@ -65,7 +68,7 @@ func run(args []string) (string, error) {
 			return "", err
 		}
 		message, commandErr = withCopyOfWorkTree(promotePath, func(workTreeCopy string) (string, error) {
-			return command.PromoteCommand(ctx, workTreeCopy, *promoteToken)
+			return command.PromoteCommand(ctx, *promoteProviderType, workTreeCopy, *promoteToken)
 		})
 	case "status":
 		err := statusCommand.Parse(args[2:])
@@ -73,7 +76,7 @@ func run(args []string) (string, error) {
 			return "", err
 		}
 		message, commandErr = withCopyOfWorkTree(statusPath, func(workTreeCopy string) (string, error) {
-			return command.StatusCommand(ctx, workTreeCopy, *statusToken)
+			return command.StatusCommand(ctx, *statusProviderType, workTreeCopy, *statusToken)
 		})
 	default:
 		flag.PrintDefaults()

--- a/main_test.go
+++ b/main_test.go
@@ -14,6 +14,8 @@ func TestCIRequirements(t *testing.T) {
 	reqEnvVars := []string{
 		"AZDO_URL",
 		"AZDO_PAT",
+		"GITHUB_URL",
+		"GITHUB_TOKEN",
 	}
 
 	for _, envVar := range reqEnvVars {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -16,8 +16,8 @@ func getConfig(path string) (config.Config, error) {
 	return cfg, nil
 }
 
-func getRepository(ctx context.Context, path, token string) (*git.Repository, error) {
-	repo, err := git.LoadRepository(ctx, path, git.ProviderTypeAzdo, token)
+func getRepository(ctx context.Context, providerType string, path, token string) (*git.Repository, error) {
+	repo, err := git.LoadRepository(ctx, path, providerType, token)
 	if err != nil {
 		return nil, fmt.Errorf("could not load repository: %w", err)
 	}

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -122,17 +122,7 @@ func TestE2EGitHub(t *testing.T) {
 
 	require.Equal(t, "created promotions pull request", newCommandMsgDev)
 
-	// TODO: Remove when auto merge is enabled in GitHub
-	// START - Fake auto merge in GitHub
-	pathFake := testCloneRepositoryAndValidateTag(t, url, username, password, promoteBranchName, group, "dev", app, tag)
-	repoDevFake := testGetRepository(t, pathFake)
-	revDevFake := testGetRepositoryHeadRevision(t, repoDevFake)
-
-	testMergePR(t, ctx, providerType, url, password, promoteBranchName, revDevFake)
-	// STOP - Fake auto merge in GitHub
-
 	path = testCloneRepositoryAndValidateTag(t, url, username, password, defaultBranch, group, "dev", app, tag)
-
 	repoDev := testGetRepository(t, path)
 	revDev := testGetRepositoryHeadRevision(t, repoDev)
 

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -36,7 +36,7 @@ func TestE2EAzureDevOps(t *testing.T) {
 	repoDev := testGetRepository(t, path)
 	revDev := testGetRepositoryHeadRevision(t, repoDev)
 
-	testSetAzureDevOpsStatus(t, revDev, group, "dev", url, password, true)
+	testSetAzureDevOpsStatus(t, ctx, revDev, group, "dev", url, password, true)
 
 	// Test QA
 	promoteCommandMsgQa, err := PromoteCommand(ctx, path, password)
@@ -61,7 +61,7 @@ func TestE2EAzureDevOps(t *testing.T) {
 	repoMergedQa := testGetRepository(t, path)
 	revMergedQa := testGetRepositoryHeadRevision(t, repoMergedQa)
 
-	testSetAzureDevOpsStatus(t, revMergedQa, group, "qa", url, password, true)
+	testSetAzureDevOpsStatus(t, ctx, revMergedQa, group, "qa", url, password, true)
 
 	// Test PROD
 	promoteCommandMsgProd, err := PromoteCommand(ctx, path, password)
@@ -85,5 +85,5 @@ func TestE2EAzureDevOps(t *testing.T) {
 	repoMergedProd := testGetRepository(t, path)
 	revMergedProd := testGetRepositoryHeadRevision(t, repoMergedProd)
 
-	testSetAzureDevOpsStatus(t, revMergedProd, group, "prod", url, password, true)
+	testSetAzureDevOpsStatus(t, ctx, revMergedProd, group, "prod", url, password, true)
 }

--- a/pkg/command/helpers_test.go
+++ b/pkg/command/helpers_test.go
@@ -13,17 +13,6 @@ import (
 	"github.com/xenitab/gitops-promotion/pkg/git"
 )
 
-func testGetEnvOrSkip(t *testing.T, key string) string {
-	t.Helper()
-
-	value := os.Getenv(key)
-	if value == "" {
-		t.Skipf("Skipping test since environment variable %q is not set", key)
-	}
-
-	return value
-}
-
 func testCloneRepositoryAndValidateTag(t *testing.T, url, username, password, branchName, group, env, app, tag string) string {
 	t.Helper()
 

--- a/pkg/command/helpers_test.go
+++ b/pkg/command/helpers_test.go
@@ -86,20 +86,30 @@ func testGetRepositoryHeadRevision(t *testing.T, repo *git2go.Repository) string
 	return rev
 }
 
-func testSetAzureDevOpsStatus(t *testing.T, ctx context.Context, revision, group, env, url, token string, succeeded bool) {
+func testSetStatus(
+	t *testing.T,
+	ctx context.Context,
+	providerType git.ProviderType,
+	revision,
+	group,
+	env,
+	url,
+	token string,
+	succeeded bool,
+) {
 	t.Helper()
 
-	repo, err := git.NewGitProvider(ctx, git.ProviderTypeAzdo, url, token)
+	repo, err := git.NewGitProvider(ctx, providerType, url, token)
 	require.NoError(t, err)
 
 	err = repo.SetStatus(ctx, revision, group, env, succeeded)
 	require.NoError(t, err)
 }
 
-func testMergeAzureDevOpsPR(t *testing.T, ctx context.Context, url, token, branch, revision string) {
+func testMergePR(t *testing.T, ctx context.Context, providerType git.ProviderType, url, token, branch, revision string) {
 	t.Helper()
 
-	provider, err := git.NewAzdoGITProvider(ctx, url, token)
+	provider, err := git.NewGitProvider(ctx, providerType, url, token)
 	require.NoError(t, err)
 
 	pr, err := provider.GetPRWithBranch(ctx, branch, "main")

--- a/pkg/command/helpers_test.go
+++ b/pkg/command/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	scgit "github.com/fluxcd/source-controller/pkg/git"
 	git2go "github.com/libgit2/git2go/v31"
 	azdo "github.com/microsoft/azure-devops-go-api/azuredevops"
 	azdogit "github.com/microsoft/azure-devops-go-api/azuredevops/git"
@@ -66,32 +65,8 @@ func testSleepBackoff(t *testing.T, i int) {
 func testCloneRepository(t *testing.T, url, username, password, path, branchName string) {
 	t.Helper()
 
-	auth := testBasicAuthMethod(t, username, password)
-
-	_, err := git2go.Clone(url, path, &git2go.CloneOptions{
-		FetchOptions: &git2go.FetchOptions{
-			DownloadTags: git2go.DownloadTagsNone,
-			RemoteCallbacks: git2go.RemoteCallbacks{
-				CredentialsCallback: auth.CredCallback,
-			},
-		},
-		CheckoutBranch: branchName,
-	})
+	err := git.Clone(url, username, password, path, branchName)
 	require.NoError(t, err)
-}
-
-func testBasicAuthMethod(t *testing.T, username, password string) *scgit.Auth {
-	t.Helper()
-
-	credCallback := func(url string, usernameFromURL string, allowedTypes git2go.CredType) (*git2go.Cred, error) {
-		cred, err := git2go.NewCredUserpassPlaintext(username, password)
-		if err != nil {
-			return nil, err
-		}
-		return cred, nil
-	}
-
-	return &scgit.Auth{CredCallback: credCallback}
 }
 
 func testGetRepository(t *testing.T, path string) *git2go.Repository {

--- a/pkg/command/new.go
+++ b/pkg/command/new.go
@@ -6,12 +6,12 @@ import (
 	"github.com/xenitab/gitops-promotion/pkg/git"
 )
 
-func NewCommand(ctx context.Context, path, token, group, app, tag string) (string, error) {
+func NewCommand(ctx context.Context, providerType string, path, token, group, app, tag string) (string, error) {
 	cfg, err := getConfig(path)
 	if err != nil {
 		return "", err
 	}
-	repo, err := getRepository(ctx, path, token)
+	repo, err := getRepository(ctx, providerType, path, token)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/command/promote.go
+++ b/pkg/command/promote.go
@@ -11,12 +11,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func PromoteCommand(ctx context.Context, path, token string) (string, error) {
+func PromoteCommand(ctx context.Context, providerType string, path, token string) (string, error) {
 	cfg, err := getConfig(path)
 	if err != nil {
 		return "", fmt.Errorf("could not get configuration: %w", err)
 	}
-	repo, err := getRepository(ctx, path, token)
+	repo, err := getRepository(ctx, providerType, path, token)
 	if err != nil {
 		return "", fmt.Errorf("could not get repository: %w", err)
 	}

--- a/pkg/command/promote.go
+++ b/pkg/command/promote.go
@@ -66,7 +66,7 @@ func promote(ctx context.Context, cfg config.Config, repo *git.Repository, state
 	if err != nil {
 		return "", fmt.Errorf("could not commit changes: %w", err)
 	}
-	err = repo.Push(state.BranchName())
+	err = repo.Push(state.BranchName(), true)
 	if err != nil {
 		return "", fmt.Errorf("could not push changes: %w", err)
 	}

--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -9,12 +9,12 @@ import (
 	"github.com/xenitab/gitops-promotion/pkg/git"
 )
 
-func StatusCommand(ctx context.Context, path, token string) (string, error) {
+func StatusCommand(ctx context.Context, providerType string, path, token string) (string, error) {
 	cfg, err := getConfig(path)
 	if err != nil {
 		return "", err
 	}
-	repo, err := getRepository(ctx, path, token)
+	repo, err := getRepository(ctx, providerType, path, token)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -183,7 +183,7 @@ func (g *AzdoGITProvider) SetStatus(ctx context.Context, sha string, group strin
 		state = &git.GitStatusStateValues.Failed
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	createArgs := git.CreateCommitStatusArgs{

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
@@ -172,6 +173,37 @@ func (g *AzdoGITProvider) GetStatus(ctx context.Context, sha string, group strin
 	return Status{}, fmt.Errorf("no status found for sha %q", sha)
 }
 
+func (g *AzdoGITProvider) SetStatus(ctx context.Context, sha string, group string, env string, succeeded bool) error {
+	genre := "fluxcd"
+	description := fmt.Sprintf("%s-%s-%s", group, env, sha)
+	name := fmt.Sprintf("kind/%s-%s", group, env)
+
+	state := &git.GitStatusStateValues.Succeeded
+	if !succeeded {
+		state = &git.GitStatusStateValues.Failed
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	createArgs := git.CreateCommitStatusArgs{
+		Project:      &g.proj,
+		RepositoryId: &g.repo,
+		CommitId:     &sha,
+		GitCommitStatusToCreate: &git.GitStatus{
+			Description: &description,
+			State:       state,
+			Context: &git.GitStatusContext{
+				Genre: &genre,
+				Name:  &name,
+			},
+		},
+	}
+
+	_, err := g.client.CreateCommitStatus(ctx, createArgs)
+	return err
+}
+
 func (g *AzdoGITProvider) MergePR(ctx context.Context, id int, sha string) error {
 	args := git.UpdatePullRequestArgs{
 		Project:       &g.proj,
@@ -246,4 +278,10 @@ func (g *AzdoGITProvider) GetPRThatCausedCommit(ctx context.Context, sha string)
 	}
 
 	return result, nil
+}
+
+type azureDevOpsRepository struct {
+	organizationURL string
+	project         string
+	repository      string
 }

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -279,9 +279,3 @@ func (g *AzdoGITProvider) GetPRThatCausedCommit(ctx context.Context, sha string)
 
 	return result, nil
 }
-
-type azureDevOpsRepository struct {
-	organizationURL string
-	project         string
-	repository      string
-}

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -53,8 +54,8 @@ func NewGitHubGITProvider(ctx context.Context, remoteURL, token string) (*GitHub
 
 	_, _, err = client.Repositories.List(ctx, "", nil)
 	if err != nil {
-		githubError, ok := err.(*github.ErrorResponse)
-		if ok {
+		var githubError *github.ErrorResponse
+		if errors.As(err, &githubError) {
 			if githubError.Response.StatusCode == 401 {
 				return nil, fmt.Errorf("unable to authenticate using token")
 			}
@@ -113,7 +114,8 @@ func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, aut
 		updateOpts := &github.PullRequestBranchUpdateOptions{}
 		_, _, err := g.client.PullRequests.UpdateBranch(ctx, g.owner, g.repo, *pr.Number, updateOpts)
 
-		if _, ok := err.(*github.AcceptedError); ok {
+		var githubError *github.AcceptedError
+		if errors.As(err, &githubError) {
 			return nil
 		}
 

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v35/github"
+	"github.com/google/go-github/v37/github"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -206,9 +206,9 @@ func (g *GitHubGITProvider) MergePR(ctx context.Context, id int, sha string) err
 			result, res, err = g.client.PullRequests.Merge(ctx, g.owner, g.repo, id, "", opts)
 			if err != nil && res.StatusCode == 405 {
 				updateOpts := &github.PullRequestBranchUpdateOptions{}
-				_, _, err = g.client.PullRequests.UpdateBranch(ctx, g.owner, g.repo, id, updateOpts)
-				if err != nil {
-					return err
+				_, _, innerErr := g.client.PullRequests.UpdateBranch(ctx, g.owner, g.repo, id, updateOpts)
+				if innerErr != nil {
+					return innerErr
 				}
 			}
 			return err

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -180,6 +180,38 @@ func (g *GitHubGITProvider) GetStatus(ctx context.Context, sha string, group str
 	return Status{}, fmt.Errorf("no status found for sha %q", sha)
 }
 
+func (g *GitHubGITProvider) SetStatus(ctx context.Context, sha string, group string, env string, succeeded bool) error {
+	// genre := "fluxcd"
+	// description := fmt.Sprintf("%s-%s-%s", group, env, sha)
+	// name := fmt.Sprintf("kind/%s-%s", group, env)
+
+	// state := &git.GitStatusStateValues.Succeeded
+	// if !succeeded {
+	// 	state = &git.GitStatusStateValues.Failed
+	// }
+
+	// ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// defer cancel()
+
+	// createArgs := git.CreateCommitStatusArgs{
+	// 	Project:      &g.proj,
+	// 	RepositoryId: &g.repo,
+	// 	CommitId:     &sha,
+	// 	GitCommitStatusToCreate: &git.GitStatus{
+	// 		Description: &description,
+	// 		State:       state,
+	// 		Context: &git.GitStatusContext{
+	// 			Genre: &genre,
+	// 			Name:  &name,
+	// 		},
+	// 	},
+	// }
+
+	// _, err := g.client.CreateCommitStatus(ctx, createArgs)
+	// return err
+	return nil
+}
+
 func (g *GitHubGITProvider) MergePR(ctx context.Context, id int, sha string) error {
 	return nil
 	// args := git.UpdatePullRequestArgs{

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -80,11 +80,18 @@ func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, aut
 	// Update PR if it already exists
 	listOpts := &github.PullRequestListOptions{
 		State: "open",
-		Head:  sourceName,
 		Base:  targetName,
 	}
 
-	prs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, listOpts)
+	openPrs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, listOpts)
+
+	var prs []*github.PullRequest
+	for _, pr := range openPrs {
+		if pr.Head.Ref == &sourceName {
+			prs = append(prs, pr)
+		}
+	}
+
 	if err == nil && len(prs) > 0 {
 		if len(prs) != 1 {
 			return fmt.Errorf("Received more than one PRs when listing: %d", len(prs))

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -140,6 +140,9 @@ func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, aut
 			PullRequestID: pr.GetNodeID(),
 		}
 		err = client.Mutate(ctx, &mutation, input, nil)
+		if err != nil && strings.Contains(err.Error(), "not in the correct state") {
+			err = g.MergePR(ctx, int(pr.GetNumber()), *pr.GetHead().SHA)
+		}
 	}
 	return err
 }

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -113,6 +113,10 @@ func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, aut
 		updateOpts := &github.PullRequestBranchUpdateOptions{}
 		_, _, err := g.client.PullRequests.UpdateBranch(ctx, g.owner, g.repo, *pr.Number, updateOpts)
 
+		if _, ok := err.(*github.AcceptedError); ok {
+			return nil
+		}
+
 		return err
 	}
 
@@ -271,14 +275,14 @@ func (g *GitHubGITProvider) GetPRThatCausedCommit(ctx context.Context, sha strin
 		State: "closed",
 	}
 
-	openPrs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, listOpts)
+	closedPrs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, listOpts)
 	if err != nil {
 		return PullRequest{}, err
 	}
 
 	var prs []*github.PullRequest
-	for _, pr := range openPrs {
-		if sha == *pr.Head.SHA {
+	for _, pr := range closedPrs {
+		if sha == *pr.MergeCommitSHA {
 			prs = append(prs, pr)
 		}
 	}

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -207,6 +207,9 @@ func (g *GitHubGITProvider) MergePR(ctx context.Context, id int, sha string) err
 			if err != nil && res.StatusCode == 405 {
 				updateOpts := &github.PullRequestBranchUpdateOptions{}
 				_, _, err = g.client.PullRequests.UpdateBranch(ctx, g.owner, g.repo, id, updateOpts)
+				if err != nil {
+					return err
+				}
 			}
 			return err
 		},
@@ -256,7 +259,7 @@ func (g *GitHubGITProvider) GetPRWithBranch(ctx context.Context, source, target 
 					prs = append(prs, pr)
 				}
 			}
-			if len(prs) == 0 {
+			if len(prs) != 1 {
 				return fmt.Errorf("no PR found for branches %q-%q", source, target)
 			}
 			return nil
@@ -290,7 +293,7 @@ func (g *GitHubGITProvider) GetPRThatCausedCommit(ctx context.Context, sha strin
 					prs = append(prs, pr)
 				}
 			}
-			if len(prs) == 0 {
+			if len(prs) != 1 {
 				return fmt.Errorf("no PR found for sha: %s", sha)
 			}
 			return nil

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -1,0 +1,258 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/go-github/v35/github"
+	"golang.org/x/oauth2"
+)
+
+// GitHubGITProvider ...
+type GitHubGITProvider struct {
+	client *github.Client
+	owner  string
+	repo   string
+}
+
+// NewGitHubGITProvider ...
+func NewGitHubGITProvider(ctx context.Context, remoteURL, token string) (*GitHubGITProvider, error) {
+	if remoteURL == "" {
+		return nil, fmt.Errorf("remoteURL empty")
+	}
+
+	if token == "" {
+		return nil, fmt.Errorf("token empty")
+	}
+
+	host, id, err := parseGitAddress(remoteURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if host != "https://github.com" {
+		return nil, fmt.Errorf("host does not start with https://github.com: %s", host)
+	}
+
+	comp := strings.Split(id, "/")
+	if len(comp) != 2 {
+		return nil, fmt.Errorf("invalid repository id %q", id)
+	}
+
+	owner := comp[0]
+	repo := comp[1]
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+
+	_, _, err = client.Repositories.List(ctx, "", nil)
+	if err != nil {
+		githubError, ok := err.(*github.ErrorResponse)
+		if ok {
+			if githubError.Response.StatusCode == 401 {
+				return nil, fmt.Errorf("unable to authenticate using token")
+			}
+		}
+
+		return nil, err
+	}
+
+	return &GitHubGITProvider{
+		client: client,
+		owner:  owner,
+		repo:   repo,
+	}, nil
+}
+
+// CreatePR ...
+func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) error {
+	sourceName := branchName
+	targetName := DefaultBranch
+	title := state.Title()
+	description, err := state.Description()
+	if err != nil {
+		return err
+	}
+
+	// Update PR if it already exists
+	listOpts := &github.PullRequestListOptions{
+		State: "open",
+		Head:  sourceName,
+		Base:  targetName,
+	}
+
+	prs, _, err := g.client.PullRequests.List(ctx, g.owner, g.repo, listOpts)
+	if err == nil && len(prs) > 0 {
+		if len(prs) != 1 {
+			return fmt.Errorf("Received more than one PRs when listing: %d", len(prs))
+		}
+
+		pr := (prs)[0]
+		// TODO: Continue with automerge stuff when this i merged: https://github.com/google/go-github/pull/1896
+		// var autoCompleteSetBy *webapi.IdentityRef
+		// if auto {
+		// 	autoCompleteSetBy = pr.CreatedBy
+		// }
+
+		updateOpts := &github.PullRequestBranchUpdateOptions{}
+		_, _, err := g.client.PullRequests.UpdateBranch(ctx, g.owner, g.repo, *pr.Number, updateOpts)
+
+		return err
+	}
+
+	// Create new PR
+	// deleteSourceBranch := true
+	// createArgs := git.CreatePullRequestArgs{
+	// 	Project:      &g.proj,
+	// 	RepositoryId: &g.repo,
+	// 	GitPullRequestToCreate: &git.GitPullRequest{
+	// 		Title:         &title,
+	// 		Description:   &description,
+	// 		SourceRefName: &sourceRefName,
+	// 		TargetRefName: &targetRefName,
+	// 		CompletionOptions: &git.GitPullRequestCompletionOptions{
+	// 			DeleteSourceBranch: &deleteSourceBranch,
+	// 		},
+	// 	},
+	// }
+	// pr, err := g.client.CreatePullRequest(ctx, createArgs)
+	createOpts := &github.NewPullRequest{
+		Title:               &title,
+		Body:                &description,
+		Head:                &sourceName,
+		Base:                &targetName,
+		MaintainerCanModify: github.Bool(true),
+	}
+	_, _, err = g.client.PullRequests.Create(ctx, g.owner, g.repo, createOpts)
+	return err
+
+	// TODO: Continue with automerge stuff when this i merged: https://github.com/google/go-github/pull/1896
+	// if !auto {
+	// 	return nil
+	// }
+
+	// This update is done to set auto merge. The reason this is not
+	// done when creating is because there is no reasonable way to
+	// get the identity ref other than from the response.
+	// updatePR := git.GitPullRequest{
+	// 	AutoCompleteSetBy: pr.CreatedBy,
+	// }
+	// updateArgs := git.UpdatePullRequestArgs{
+	// 	Project:                &g.proj,
+	// 	RepositoryId:           &g.repo,
+	// 	PullRequestId:          pr.PullRequestId,
+	// 	GitPullRequestToUpdate: &updatePR,
+	// }
+	// _, err = g.client.UpdatePullRequest(ctx, updateArgs)
+	// return err
+}
+
+func (g *GitHubGITProvider) GetStatus(ctx context.Context, sha string, group string, env string) (Status, error) {
+	return Status{}, nil
+	// args := git.GetStatusesArgs{
+	// 	Project:      &g.proj,
+	// 	RepositoryId: &g.repo,
+	// 	CommitId:     &sha,
+	// }
+	// statuses, err := g.client.GetStatuses(ctx, args)
+	// if err != nil {
+	// 	return Status{}, err
+	// }
+	// genre := "fluxcd"
+	// name := fmt.Sprintf("%s-%s", group, env)
+	// for i := range *statuses {
+	// 	s := (*statuses)[i]
+	// 	comp := strings.Split(*s.Context.Name, "/")
+	// 	if len(comp) != 2 {
+	// 		return Status{}, fmt.Errorf("status name in wrong format: %q", *s.Context.Name)
+	// 	}
+	// 	if *s.Context.Genre == genre && comp[1] == name {
+	// 		return Status{
+	// 			Succeeded: *s.State == git.GitStatusStateValues.Succeeded,
+	// 		}, nil
+	// 	}
+	// }
+	// return Status{}, fmt.Errorf("no status found for sha %q", sha)
+}
+
+func (g *GitHubGITProvider) MergePR(ctx context.Context, id int, sha string) error {
+	return nil
+	// args := git.UpdatePullRequestArgs{
+	// 	Project:       &g.proj,
+	// 	RepositoryId:  &g.repo,
+	// 	PullRequestId: &id,
+	// 	GitPullRequestToUpdate: &git.GitPullRequest{
+	// 		Status: &git.PullRequestStatusValues.Completed,
+	// 		LastMergeSourceCommit: &git.GitCommitRef{
+	// 			CommitId: &sha,
+	// 		},
+	// 	},
+	// }
+	// _, err := g.client.UpdatePullRequest(ctx, args)
+	// return err
+}
+
+func (g *GitHubGITProvider) GetPRWithBranch(ctx context.Context, source, target string) (PullRequest, error) {
+	return PullRequest{}, nil
+	// sourceRefName := fmt.Sprintf("refs/heads/%s", source)
+	// targetRefName := fmt.Sprintf("refs/heads/%s", target)
+	// args := git.GetPullRequestsArgs{
+	// 	Project:      &g.proj,
+	// 	RepositoryId: &g.repo,
+	// 	SearchCriteria: &git.GitPullRequestSearchCriteria{
+	// 		SourceRefName: &sourceRefName,
+	// 		TargetRefName: &targetRefName,
+	// 	},
+	// }
+	// prs, err := g.client.GetPullRequests(ctx, args)
+	// if err != nil {
+	// 	return PullRequest{}, err
+	// }
+	// if len(*prs) == 0 {
+	// 	return PullRequest{}, fmt.Errorf("no PR found for branches %q-%q", source, target)
+	// }
+
+	// pr := (*prs)[0]
+
+	// result, err := newPR(pr.PullRequestId, pr.Title, pr.Description, nil)
+	// if err != nil {
+	// 	return PullRequest{}, err
+	// }
+
+	// return result, nil
+}
+
+func (g *GitHubGITProvider) GetPRThatCausedCommit(ctx context.Context, sha string) (PullRequest, error) {
+	return PullRequest{}, nil
+	// args := git.GetPullRequestQueryArgs{
+	// 	Project:      &g.proj,
+	// 	RepositoryId: &g.repo,
+	// 	Queries: &git.GitPullRequestQuery{
+	// 		Queries: &[]git.GitPullRequestQueryInput{
+	// 			{
+	// 				Items: &[]string{sha},
+	// 				Type:  &git.GitPullRequestQueryTypeValues.LastMergeCommit,
+	// 			},
+	// 		},
+	// 	},
+	// }
+	// query, err := g.client.GetPullRequestQuery(ctx, args)
+	// if err != nil {
+	// 	return PullRequest{}, err
+	// }
+	// results := *query.Results
+	// if len(results[0]) == 0 {
+	// 	return PullRequest{}, fmt.Errorf("no PR found for commit %q", sha)
+	// }
+	// pr := results[0][sha][0]
+
+	// result, err := newPR(pr.PullRequestId, pr.Title, pr.Description, nil)
+	// if err != nil {
+	// 	return PullRequest{}, err
+	// }
+
+	// return result, nil
+}

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v35/github"
 	"golang.org/x/oauth2"
@@ -181,35 +182,25 @@ func (g *GitHubGITProvider) GetStatus(ctx context.Context, sha string, group str
 }
 
 func (g *GitHubGITProvider) SetStatus(ctx context.Context, sha string, group string, env string, succeeded bool) error {
-	// genre := "fluxcd"
-	// description := fmt.Sprintf("%s-%s-%s", group, env, sha)
-	// name := fmt.Sprintf("kind/%s-%s", group, env)
+	description := fmt.Sprintf("%s-%s-%s", group, env, sha)
+	name := fmt.Sprintf("kind/%s-%s", group, env)
 
-	// state := &git.GitStatusStateValues.Succeeded
-	// if !succeeded {
-	// 	state = &git.GitStatusStateValues.Failed
-	// }
+	state := "success"
+	if !succeeded {
+		state = "failure"
+	}
 
-	// ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	// defer cancel()
+	status := &github.RepoStatus{
+		State:       &state,
+		Context:     &name,
+		Description: &description,
+	}
 
-	// createArgs := git.CreateCommitStatusArgs{
-	// 	Project:      &g.proj,
-	// 	RepositoryId: &g.repo,
-	// 	CommitId:     &sha,
-	// 	GitCommitStatusToCreate: &git.GitStatus{
-	// 		Description: &description,
-	// 		State:       state,
-	// 		Context: &git.GitStatusContext{
-	// 			Genre: &genre,
-	// 			Name:  &name,
-	// 		},
-	// 	},
-	// }
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 
-	// _, err := g.client.CreateCommitStatus(ctx, createArgs)
-	// return err
-	return nil
+	_, _, err := g.client.Repositories.CreateStatus(ctx, g.owner, g.repo, sha, status)
+	return err
 }
 
 func (g *GitHubGITProvider) MergePR(ctx context.Context, id int, sha string) error {

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -99,7 +100,8 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 
 	When("Creating PR with empty values", func() {
 		It("returns error", func() {
-			gitHubError, ok := err.(*github.ErrorResponse)
+			var gitHubError *github.ErrorResponse
+			ok := errors.As(err, &gitHubError)
 			Expect(ok).To(Equal(true))
 			body, bodyErr := ioutil.ReadAll(gitHubError.Response.Body)
 			Expect(bodyErr).To(BeNil())
@@ -116,7 +118,8 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 		})
 
 		It("returns error", func() {
-			gitHubError, ok := err.(*github.ErrorResponse)
+			var gitHubError *github.ErrorResponse
+			ok := errors.As(err, &gitHubError)
 			Expect(ok).To(Equal(true))
 			body, bodyErr := ioutil.ReadAll(gitHubError.Response.Body)
 			Expect(bodyErr).To(BeNil())
@@ -249,7 +252,8 @@ var _ = Describe("GitHubGITProvider GetStatus", func() {
 
 	When("Getting status of empty sha", func() {
 		It("return error", func() {
-			gitHubError, ok := err.(*github.ErrorResponse)
+			var gitHubError *github.ErrorResponse
+			ok := errors.As(err, &gitHubError)
 			Expect(ok).To(Equal(true))
 			body, bodyErr := ioutil.ReadAll(gitHubError.Response.Body)
 			Expect(bodyErr).To(BeNil())
@@ -366,7 +370,8 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 
 	When("Merging PR with empty prID and SHA", func() {
 		It("return error", func() {
-			gitHubError, ok := err.(*github.ErrorResponse)
+			var gitHubError *github.ErrorResponse
+			ok := errors.As(err, &gitHubError)
 			Expect(ok).To(Equal(true))
 			body, bodyErr := ioutil.ReadAll(gitHubError.Response.Body)
 			Expect(bodyErr).To(BeNil())

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -67,6 +67,7 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
+	providerTypeString := "github"
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -137,7 +138,7 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, DefaultBranch)
 			Expect(e).To(BeNil())
 
-			repo, e := LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e := LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			e = repo.CreateBranch(branchName, true)
@@ -155,7 +156,7 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, branchName)
 			Expect(e).To(BeNil())
 
-			repo, e = LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e = LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			f, e := os.Create(fmt.Sprintf("%s/%s.txt", tmpDir, branchName))
@@ -189,6 +190,7 @@ var _ = Describe("GitHubGITProvider GetStatus", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
+	providerTypeString := "github"
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -240,7 +242,7 @@ var _ = Describe("GitHubGITProvider GetStatus", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, DefaultBranch)
 			Expect(e).To(BeNil())
 
-			repo, e := LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e := LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			f, e := os.Create(fmt.Sprintf("%s/%s.txt", tmpDir, DefaultBranch))
@@ -304,6 +306,7 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
+	providerTypeString := "github"
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -357,7 +360,7 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, DefaultBranch)
 			Expect(e).To(BeNil())
 
-			repo, e := LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e := LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			e = repo.CreateBranch(branchName, true)
@@ -375,7 +378,7 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, branchName)
 			Expect(e).To(BeNil())
 
-			repo, e = LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e = LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			f, e := os.Create(fmt.Sprintf("%s/%s.txt", tmpDir, branchName))
@@ -419,6 +422,7 @@ var _ = Describe("GitHubGITProvider GetPRWithBranch", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
+	providerTypeString := "github"
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -465,7 +469,7 @@ var _ = Describe("GitHubGITProvider GetPRWithBranch", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, DefaultBranch)
 			Expect(e).To(BeNil())
 
-			repo, e := LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e := LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			e = repo.CreateBranch(branchName, true)
@@ -483,7 +487,7 @@ var _ = Describe("GitHubGITProvider GetPRWithBranch", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, branchName)
 			Expect(e).To(BeNil())
 
-			repo, e = LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e = LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			f, e := os.Create(fmt.Sprintf("%s/%s.txt", tmpDir, branchName))
@@ -523,6 +527,7 @@ var _ = Describe("GitHubGITProvider GetPRThatCausedCommit", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
+	providerTypeString := "github"
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -570,7 +575,7 @@ var _ = Describe("GitHubGITProvider GetPRThatCausedCommit", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, DefaultBranch)
 			Expect(e).To(BeNil())
 
-			repo, e := LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e := LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			e = repo.CreateBranch(branchName, true)
@@ -588,7 +593,7 @@ var _ = Describe("GitHubGITProvider GetPRThatCausedCommit", func() {
 			e = Clone(remoteURL, "pat", token, tmpDir, branchName)
 			Expect(e).To(BeNil())
 
-			repo, e = LoadRepository(ctx, tmpDir, ProviderTypeGitHub, token)
+			repo, e = LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
 			f, e := os.Create(fmt.Sprintf("%s/%s.txt", tmpDir, branchName))

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -249,9 +249,10 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 			Expect(e).To(BeNil())
 		})
 
-		It("returns an error", func() {
-			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(ContainSubstring("not in the correct state"))
+		It("merges the PR directly", func() {
+			Expect(err).To(BeNil())
+			_, e := provider.GetPRWithBranch(ctx, branchName, DefaultBranch)
+			Expect(e.Error()).To(ContainSubstring("no PR found"))
 		})
 
 		When("and the repository has branch protection requiring passing statuses", func() {

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -141,10 +141,10 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 			repo, e := LoadRepository(ctx, tmpDir, providerTypeString, token)
 			Expect(e).To(BeNil())
 
-			e = repo.CreateBranch(branchName, true)
+			e = repo.CreateBranch(branchName, false)
 			Expect(e).To(BeNil())
 
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = os.RemoveAll(tmpDir)
@@ -257,7 +257,7 @@ var _ = Describe("GitHubGITProvider GetStatus", func() {
 			_, e = repo.CreateCommit(DefaultBranch, fmt.Sprintln(time.Now()))
 			Expect(e).To(BeNil())
 
-			e = repo.Push(DefaultBranch)
+			e = repo.Push(DefaultBranch, true)
 			Expect(e).To(BeNil())
 
 			sha, e := repo.GetCurrentCommit()
@@ -366,7 +366,7 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 			e = repo.CreateBranch(branchName, true)
 			Expect(e).To(BeNil())
 
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = os.RemoveAll(tmpDir)
@@ -395,7 +395,7 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 
 			state.Sha = sha.String()
 
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = provider.CreatePR(ctx, branchName, false, state)
@@ -475,7 +475,7 @@ var _ = Describe("GitHubGITProvider GetPRWithBranch", func() {
 			e = repo.CreateBranch(branchName, true)
 			Expect(e).To(BeNil())
 
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = os.RemoveAll(tmpDir)
@@ -504,7 +504,7 @@ var _ = Describe("GitHubGITProvider GetPRWithBranch", func() {
 
 			state.Sha = sha.String()
 
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = provider.CreatePR(ctx, branchName, false, state)
@@ -581,7 +581,7 @@ var _ = Describe("GitHubGITProvider GetPRThatCausedCommit", func() {
 			e = repo.CreateBranch(branchName, true)
 			Expect(e).To(BeNil())
 
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = os.RemoveAll(tmpDir)
@@ -608,9 +608,7 @@ var _ = Describe("GitHubGITProvider GetPRThatCausedCommit", func() {
 			sha, e := repo.CreateCommit(branchName, fmt.Sprintln(time.Now()))
 			Expect(e).To(BeNil())
 
-			state.Sha = sha.String()
-
-			e = repo.Push(branchName)
+			e = repo.Push(branchName, true)
 			Expect(e).To(BeNil())
 
 			e = provider.CreatePR(ctx, branchName, false, state)

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -269,9 +269,33 @@ var _ = Describe("GitHubGITProvider GetStatus", func() {
 			Expect(e).To(BeNil())
 		})
 
-		It("to return an error", func() {
+		It("to returns an error", func() {
 			Expect(err.Error()).To(ContainSubstring("no status found for sha"))
 			Expect(status.Succeeded).To(Equal(false))
+		})
+
+		When("and when a status is set to failure", func() {
+			BeforeEach(func() {
+				e := provider.SetStatus(ctx, state.Sha, state.Group, state.Env, false)
+				Expect(e).To(BeNil())
+			})
+
+			It("reports failure", func() {
+				Expect(err).To(BeNil())
+				Expect(status.Succeeded).To(Equal(false))
+			})
+		})
+
+		When("and when a status is set to success", func() {
+			BeforeEach(func() {
+				e := provider.SetStatus(ctx, state.Sha, state.Group, state.Env, true)
+				Expect(e).To(BeNil())
+			})
+
+			It("reports succeeds", func() {
+				Expect(err).To(BeNil())
+				Expect(status.Succeeded).To(Equal(true))
+			})
 		})
 	})
 })

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -67,7 +67,7 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
-	providerTypeString := "github"
+	providerTypeString := string(ProviderTypeGitHub)
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -218,7 +218,7 @@ var _ = Describe("GitHubGITProvider GetStatus", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
-	providerTypeString := "github"
+	providerTypeString := string(ProviderTypeGitHub)
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -334,7 +334,7 @@ var _ = Describe("GitHubGITProvider MergePR", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
-	providerTypeString := "github"
+	providerTypeString := string(ProviderTypeGitHub)
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -450,7 +450,7 @@ var _ = Describe("GitHubGITProvider GetPRWithBranch", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
-	providerTypeString := "github"
+	providerTypeString := string(ProviderTypeGitHub)
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {
@@ -555,7 +555,7 @@ var _ = Describe("GitHubGITProvider GetPRThatCausedCommit", func() {
 	ctx := context.Background()
 	remoteURL := os.Getenv("GITHUB_URL")
 	token := os.Getenv("GITHUB_TOKEN")
-	providerTypeString := "github"
+	providerTypeString := string(ProviderTypeGitHub)
 	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
 
 	BeforeEach(func() {

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v35/github"
+	"github.com/google/go-github/v37/github"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -1,0 +1,126 @@
+package git
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v35/github"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestNewGitHubGITProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "GitHubProvider")
+}
+
+var _ = Describe("NewGitHubGITProvider", func() {
+	var err error
+	var ctx context.Context
+
+	BeforeEach(func() {
+		err = nil
+		ctx = context.Background()
+	})
+
+	It("returns error when creating without url", func() {
+		_, err = NewGitHubGITProvider(ctx, "", "foo")
+		Expect(err).To(MatchError("remoteURL empty"))
+	})
+
+	It("returns error when creating without token", func() {
+		_, err = NewGitHubGITProvider(ctx, "https://github.com/org/repo", "")
+		Expect(err).To(MatchError("token empty"))
+	})
+
+	It("returns error when creating without github address", func() {
+		_, err = NewGitHubGITProvider(ctx, "https://foo.bar/org/repo", "foo")
+		Expect(err).To(MatchError("host does not start with https://github.com: https://foo.bar"))
+	})
+
+	It("returns error when creating with fake token", func() {
+		_, err = NewGitHubGITProvider(ctx, "https://github.com/org/repo", "foo")
+		Expect(err).To(MatchError("unable to authenticate using token"))
+	})
+
+	It("is successfully created when creating with correct token", func() {
+		var provider *GitHubGITProvider
+		remoteURL := os.Getenv("GITHUB_URL")
+		token := os.Getenv("GITHUB_TOKEN")
+
+		if remoteURL == "" || token == "" {
+			Skip("GITHUB_URL and/or GITHUB_TOKEN environment variables not set")
+		}
+
+		provider, err = NewGitHubGITProvider(ctx, remoteURL, token)
+		Expect(err).To(BeNil())
+		Expect(remoteURL).To(ContainSubstring(provider.owner))
+		Expect(remoteURL).To(ContainSubstring(provider.repo))
+	})
+})
+
+var _ = Describe("GitHubGITProvider CreatePR", func() {
+	ctx := context.Background()
+	remoteURL := os.Getenv("GITHUB_URL")
+	token := os.Getenv("GITHUB_TOKEN")
+	provider, providerErr := NewGitHubGITProvider(ctx, remoteURL, token)
+
+	BeforeEach(func() {
+		if remoteURL == "" || token == "" {
+			Skip("GITHUB_URL and/or GITHUB_TOKEN environment variables not set")
+		}
+
+		if providerErr != nil {
+			Fail("Provider initialization failed")
+		}
+	})
+
+	var err error
+	var branchName string
+	var auto bool
+	now := time.Now()
+	state := &PRState{
+		Env:   "dev",
+		Group: "testgroup",
+		App:   "testapp",
+		Tag:   now.Format("20060102150405"),
+		Sha:   "testsha",
+	}
+
+	JustBeforeEach(func() {
+		err = provider.CreatePR(ctx, branchName, auto, state)
+	})
+
+	When("Creating PR with empty values", func() {
+		It("returns error", func() {
+			gitHubError, ok := err.(*github.ErrorResponse)
+			Expect(ok).To(Equal(true))
+			body, bodyErr := ioutil.ReadAll(gitHubError.Response.Body)
+			Expect(bodyErr).To(BeNil())
+			bodyErr = gitHubError.Response.Body.Close()
+			Expect(bodyErr).To(BeNil())
+
+			Expect(string(body)).To(ContainSubstring("{\"resource\":\"PullRequest\",\"code\":\"missing_field\",\"field\":\"head\"}"))
+		})
+	})
+
+	When("Creating PR with non-existing branchName", func() {
+		BeforeEach(func() {
+			branchName = "test"
+		})
+
+		It("returns error", func() {
+			gitHubError, ok := err.(*github.ErrorResponse)
+			Expect(ok).To(Equal(true))
+			body, bodyErr := ioutil.ReadAll(gitHubError.Response.Body)
+			Expect(bodyErr).To(BeNil())
+			bodyErr = gitHubError.Response.Body.Close()
+			Expect(bodyErr).To(BeNil())
+
+			Expect(string(body)).To(ContainSubstring("{\"resource\":\"PullRequest\",\"code\":\"missing_field\",\"field\":\"head\"}"))
+		})
+	})
+})

--- a/pkg/git/provider.go
+++ b/pkg/git/provider.go
@@ -35,9 +35,9 @@ func NewGitProvider(ctx context.Context, providerType ProviderType, remoteURL, t
 
 func StringToProviderType(p string) (ProviderType, error) {
 	switch strings.ToLower(p) {
-	case "azdo":
+	case string(ProviderTypeAzdo):
 		return ProviderTypeAzdo, nil
-	case "github":
+	case string(ProviderTypeGitHub):
 		return ProviderTypeGitHub, nil
 	default:
 		return "", fmt.Errorf("Unknown provider selected: %s", p)

--- a/pkg/git/provider.go
+++ b/pkg/git/provider.go
@@ -9,7 +9,8 @@ import (
 type ProviderType string
 
 const (
-	ProviderTypeAzdo ProviderType = "azdo"
+	ProviderTypeAzdo   ProviderType = "azdo"
+	ProviderTypeGitHub ProviderType = "github"
 )
 
 type GitProvider interface {
@@ -24,6 +25,8 @@ func NewGitProvider(ctx context.Context, providerType ProviderType, remoteURL, t
 	switch providerType {
 	case ProviderTypeAzdo:
 		return NewAzdoGITProvider(ctx, remoteURL, token)
+	case ProviderTypeGitHub:
+		return NewGitHubGITProvider(ctx, remoteURL, token)
 	default:
 		return nil, fmt.Errorf("unknown provider type: %s", providerType)
 	}
@@ -33,6 +36,8 @@ func StringToProviderType(p string) (ProviderType, error) {
 	switch strings.ToLower(p) {
 	case "azdo":
 		return ProviderTypeAzdo, nil
+	case "github":
+		return ProviderTypeGitHub, nil
 	default:
 		return "", fmt.Errorf("Unknown provider selected: %s", p)
 	}

--- a/pkg/git/provider.go
+++ b/pkg/git/provider.go
@@ -15,6 +15,7 @@ const (
 
 type GitProvider interface {
 	GetStatus(ctx context.Context, sha, group, env string) (Status, error)
+	SetStatus(ctx context.Context, sha string, group string, env string, succeeded bool) error
 	CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) error
 	GetPRWithBranch(ctx context.Context, source, target string) (PullRequest, error)
 	GetPRThatCausedCommit(ctx context.Context, sha string) (PullRequest, error)

--- a/pkg/git/provider_test.go
+++ b/pkg/git/provider_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestNewGitProvider(t *testing.T) {
 	cases := []struct {
+		testDescription      string
 		providerString       string
 		expectedProviderType ProviderType
 		remoteURL            string
@@ -16,6 +17,7 @@ func TestNewGitProvider(t *testing.T) {
 		expectedError        string
 	}{
 		{
+			testDescription:      "azdo provider returns error",
 			providerString:       "azdo",
 			expectedProviderType: ProviderTypeAzdo,
 			remoteURL:            "https://dev.azure.com/organization/project/_git/repository",
@@ -23,6 +25,15 @@ func TestNewGitProvider(t *testing.T) {
 			expectedError:        "TF400813: The user '' is not authorized to access this resource.",
 		},
 		{
+			testDescription:      "github provider returns error",
+			providerString:       "github",
+			expectedProviderType: ProviderTypeGitHub,
+			remoteURL:            "https://github.com/organization/repository",
+			token:                "fake",
+			expectedError:        "GET https://api.github.com/user/repos: 401 Bad credentials []",
+		},
+		{
+			testDescription:      "fake provider returns error",
 			providerString:       "fake",
 			expectedProviderType: "",
 			remoteURL:            "",
@@ -31,7 +42,9 @@ func TestNewGitProvider(t *testing.T) {
 		},
 	}
 
-	for _, c := range cases {
+	for i, c := range cases {
+		t.Logf("Test iteration %d: %s", i, c.testDescription)
+
 		ctx := context.Background()
 
 		providerType, err := StringToProviderType(c.providerString)

--- a/pkg/git/provider_test.go
+++ b/pkg/git/provider_test.go
@@ -30,7 +30,7 @@ func TestNewGitProvider(t *testing.T) {
 			expectedProviderType: ProviderTypeGitHub,
 			remoteURL:            "https://github.com/organization/repository",
 			token:                "fake",
-			expectedError:        "GET https://api.github.com/user/repos: 401 Bad credentials []",
+			expectedError:        "unable to authenticate using token",
 		},
 		{
 			testDescription:      "fake provider returns error",

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -140,7 +140,7 @@ func (g *Repository) CreateCommit(branchName, message string) (*git2go.Oid, erro
 }
 
 // Push pushes the defined ref to remote.
-func (g *Repository) Push(branchName string) error {
+func (g *Repository) Push(branchName string, force bool) error {
 	remote, err := g.gitRepository.Remotes.Lookup(DefaultRemote)
 	if err != nil {
 		return fmt.Errorf("could not find remote %q: %w", DefaultRemote, err)
@@ -155,7 +155,13 @@ func (g *Repository) Push(branchName string) error {
 			return cred, nil
 		},
 	}
-	branches := []string{fmt.Sprintf("+refs/heads/%s", branchName)}
+
+	forceFlag := "+"
+	if !force {
+		forceFlag = ""
+	}
+
+	branches := []string{fmt.Sprintf("%srefs/heads/%s", forceFlag, branchName)}
 	err = remote.Push(branches, &git2go.PushOptions{RemoteCallbacks: callback})
 	if err != nil {
 		return fmt.Errorf("failed pushing branches %s: %w", branches, err)

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -228,12 +228,9 @@ func (g *Repository) GetPRThatCausedCurrentCommit(ctx context.Context) (PullRequ
 }
 
 func Clone(url, username, password, path, branchName string) error {
-	auth, err := basicAuthMethod(username, password)
-	if err != nil {
-		return err
-	}
+	auth := basicAuthMethod(username, password)
 
-	_, err = git2go.Clone(url, path, &git2go.CloneOptions{
+	_, err := git2go.Clone(url, path, &git2go.CloneOptions{
 		FetchOptions: &git2go.FetchOptions{
 			DownloadTags: git2go.DownloadTagsNone,
 			RemoteCallbacks: git2go.RemoteCallbacks{
@@ -246,14 +243,15 @@ func Clone(url, username, password, path, branchName string) error {
 	return err
 }
 
-func basicAuthMethod(username, password string) (*scgit.Auth, error) {
+func basicAuthMethod(username, password string) *scgit.Auth {
 	credCallback := func(url string, usernameFromURL string, allowedTypes git2go.CredType) (*git2go.Cred, error) {
 		cred, err := git2go.NewCredUserpassPlaintext(username, password)
 		if err != nil {
 			return nil, err
 		}
+
 		return cred, nil
 	}
 
-	return &scgit.Auth{CredCallback: credCallback}, nil
+	return &scgit.Auth{CredCallback: credCallback}
 }

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -18,7 +18,7 @@ type Repository struct {
 }
 
 // LoadRepository loads a local git repository.
-func LoadRepository(ctx context.Context, path string, providerType ProviderType, token string) (*Repository, error) {
+func LoadRepository(ctx context.Context, path string, providerTypeString string, token string) (*Repository, error) {
 	localRepo, err := git2go.OpenRepository(path)
 	if err != nil {
 		return &Repository{}, fmt.Errorf("could not open repository: %w", err)
@@ -27,6 +27,11 @@ func LoadRepository(ctx context.Context, path string, providerType ProviderType,
 	remote, err := localRepo.Remotes.Lookup(DefaultRemote)
 	if err != nil {
 		return nil, fmt.Errorf("could not get remote: %w", err)
+	}
+
+	providerType, err := StringToProviderType(providerTypeString)
+	if err != nil {
+		return nil, fmt.Errorf("could not get providerType: %w", err)
 	}
 
 	provider, err := NewGitProvider(ctx, providerType, remote.Url(), token)


### PR DESCRIPTION
Adds support for GitHub.

~Merge blocked by: https://github.com/google/go-github/pull/1896#issuecomment-867236851~
~When auto merge is added to the github sdk, I'll add it to this PR as well and remove the fake auto merge in the e2e test.~

UPDATE: This implementation currently uses both the "old" v3 API and the [GraphQL v4 API](https://github.com/shurcooL/githubv4) since turning on auto-merge is available only through v4 API. This is not optimal, but the GraphQL API is significantly more verbose and requires understanding of Go-style GraphQL.

GitHub appears to have a degree of separation between Git operations and metadata (i.e. pull request) operations that means it takes some time for Git operations to propagate to the metadata layer. This PR makes the provider retry some of its operations so as to hide this complexity from the workflow layer of this tool.