### PR TITLE
Alpine 3.14 updated to gcc 10.3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ COPY main.go main.go
 COPY pkg/ pkg/
 RUN CGO_ENABLED=1 go build -o gitops-promotion main.go
 
-FROM alpine:3.14.0
+FROM alpine:3.14.2
 LABEL org.opencontainers.image.source="https://github.com/XenitAB/gitops-promotion"
-# hadolint ignore=DL3018
-RUN apk add --no-cache ca-certificates tini=~0.19 libgit2=~1.1 musl=~1.2
+# hadolint ignore=DL3017,DL3018
+RUN apk upgrade --no-cache && \
+    apk add --no-cache ca-certificates tini=~0.19 libgit2=~1.1 musl=~1.2
 COPY --from=builder /workspace/gitops-promotion /usr/local/bin/
 WORKDIR /workspace
 ENTRYPOINT [ "/sbin/tini", "--", "gitops-promotion" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM golang:1.16-alpine as builder
-RUN apk add --no-cache gcc~=10.2.1_pre1-r3 pkgconfig~=1.7.3-r0 libc-dev~=0.7.2-r3
-RUN apk add --no-cache musl~=1.2 libgit2-dev~=1.1
+RUN apk add --no-cache gcc=~10.3 pkgconfig=~1.7 libc-dev=~0.7 musl=~1.2 libgit2-dev=~1.1
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -11,7 +10,8 @@ RUN CGO_ENABLED=1 go build -o gitops-promotion main.go
 
 FROM alpine:3.14.0
 LABEL org.opencontainers.image.source="https://github.com/XenitAB/gitops-promotion"
-RUN apk add --no-cache ca-certificates=20191127-r5 tini~=0.19.0-r0 libgit2~=1.1 musl~=1.2
+# hadolint ignore=DL3018
+RUN apk add --no-cache ca-certificates tini=~0.19 libgit2=~1.1 musl=~1.2
 COPY --from=builder /workspace/gitops-promotion /usr/local/bin/
 WORKDIR /workspace
 ENTRYPOINT [ "/sbin/tini", "--", "gitops-promotion" ]


### PR DESCRIPTION
This change also switches from exact version locking to locking at minor version so that we get security updates when building.