### PR TITLE
Allow passing a source work tree to gitops on

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func run(args []string) (string, error) {
 		})
 	default:
 		flag.PrintDefaults()
-		return "", fmt.Errorf("Unknown flag: %s", args[1])
+		return "", fmt.Errorf("unknown flag: %s", args[1])
 	}
 
 	if commandErr != nil {
@@ -87,7 +87,7 @@ func run(args []string) (string, error) {
 	return message, err
 }
 
-func withCopyOfWorkTree(sourcePath *string, work func(string) (string, error)) (string, error) {
+func withCopyOfWorkTree(sourcePath *string, taskFn func(string) (string, error)) (string, error) {
 	tmpPath, err := os.MkdirTemp("", "gitops-promotion-")
 	if err != nil {
 		return "", err
@@ -104,6 +104,6 @@ func withCopyOfWorkTree(sourcePath *string, work func(string) (string, error)) (
 		return "", err
 	}
 
-	message, err := work(tmpPath)
+	message, err := taskFn(tmpPath)
 	return message, err
 }


### PR DESCRIPTION
In the normal gitops-promotion use case, current working directory is the base of the repo in which the promotion takes place, which is in turn mounted into the container at a fixed position (i.e. /workspace). However, when we run the tests we want to run directly, without container packaging. Previously, we invoked the `*Command` method directly, which takes a path, but as part of the upcoming change to have e2e tests run against `Run()`, we will need to pass the working tree in as a proper argument. This PR introduces a `-sourcedir` parameter, which defaults to cwd.