### PR TITLE
Manually bump version for GitHub Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
         with:
           # gitops-promotion currently needs access to history
           fetch-depth: 0
-      - uses: xenitab/gitops-promotion@v1
+      - uses: xenitab/gitops-promotion@v0.0.8
         with:
           action: new
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -102,7 +102,7 @@ jobs:
         with:
           # gitops-promotion currently needs access to history
           fetch-depth: 0
-      - uses: xenitab/gitops-promotion@v1
+      - uses: xenitab/gitops-promotion@v0.0.8
         with:
           action: promote
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ inputs:
     requires: false
 runs:
   using: docker
-  image: docker://ghcr.io/xenitab/gitops-promotion:v0.0.7
+  image: docker://ghcr.io/xenitab/gitops-promotion:v0.0.8
   entrypoint: /usr/local/bin/action-entrypoint.sh
   env:
     ACTION: ${{ inputs.action }}


### PR DESCRIPTION
Ideally, this is something that is performed automatically the release workflow, but at this point, the priority is to get a working release out the door.

This style has the GitHub Action version strictly track the version of the gitops-promotion container.