### PR TITLE
Remove GitHub login check

### DIFF
--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -55,18 +54,6 @@ func NewGitHubGITProvider(ctx context.Context, remoteURL, token string) (*GitHub
 	tc := oauth2.NewClient(ctx, ts)
 
 	client := github.NewClient(tc)
-
-	_, _, err = client.Repositories.List(ctx, "", nil)
-	if err != nil {
-		var githubError *github.ErrorResponse
-		if errors.As(err, &githubError) {
-			if githubError.Response.StatusCode == 401 {
-				return nil, fmt.Errorf("unable to authenticate using token")
-			}
-		}
-
-		return nil, err
-	}
 
 	return &GitHubGITProvider{
 		authClient: tc,

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -103,11 +103,6 @@ var _ = Describe("NewGitHubGITProvider", func() {
 		Expect(err).To(MatchError("host does not start with https://github.com: https://foo.bar"))
 	})
 
-	It("returns error when creating with fake token", func() {
-		_, err = NewGitHubGITProvider(ctx, "https://github.com/org/repo", "foo")
-		Expect(err).To(MatchError("unable to authenticate using token"))
-	})
-
 	It("is successfully created when creating with correct token", func() {
 		var provider *GitHubGITProvider
 		remoteURL := os.Getenv("GITHUB_URL")

--- a/pkg/git/provider_test.go
+++ b/pkg/git/provider_test.go
@@ -25,14 +25,6 @@ func TestNewGitProvider(t *testing.T) {
 			expectedError:        "TF400813: The user '' is not authorized to access this resource.",
 		},
 		{
-			testDescription:      "github provider returns error",
-			providerString:       "github",
-			expectedProviderType: ProviderTypeGitHub,
-			remoteURL:            "https://github.com/organization/repository",
-			token:                "fake",
-			expectedError:        "unable to authenticate using token",
-		},
-		{
 			testDescription:      "fake provider returns error",
 			providerString:       "fake",
 			expectedProviderType: "",


### PR DESCRIPTION
Don't try to verify auth in GitHub constructor since this trips up running as a GitHub App. As it turns out, the whole workflow works fine when using a GitHub App rather than a PAT, except for the `client.Repositories.List()` call the constructor does just to verify that the creds are ok. As it turns out, listing repos like this performs a call to https://api.github.com/user/repositories which is not available to apps (that instead should call https://api.github.com/installations/repositories. Since this does not actually do anything, I'll just remove it for now.

Signed-off-by: Anders Qvist <anders.qvist@xenit.se>