### PR TITLE
Explicit message when status fails to find a branch

### DIFF
--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -22,7 +22,7 @@ func StatusCommand(ctx context.Context, providerType string, path, token string)
 	// If branch does not contain promote it was manual, return early
 	branchName, err := repo.GetBranchName()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to find current branch: %w", err)
 	}
 	if !strings.HasPrefix(branchName, git.PromoteBranchPrefix) {
 		return "Promotion was manual, skipping check", nil


### PR DESCRIPTION
The GitHub checkout action intentionally creates a detached head when checking out for PR. This creats an error which is hard to track down and this gives a unique string for that error so you can debug it. See #116 for more info about the problem.