### PR TITLE
Log mutations and present PR details to user

### DIFF
--- a/pkg/command/promote.go
+++ b/pkg/command/promote.go
@@ -23,6 +23,8 @@ func PromoteCommand(ctx context.Context, providerType string, path, token string
 	}
 	pr, err := repo.GetPRThatCausedCurrentCommit(ctx)
 	if err != nil {
+		sha, _ := repo.GetCurrentCommit()
+		log.Printf("Failed retrieving pull request for commit %s: %v", sha, err)
 		//lint:ignore nilerr should not return error
 		return "skipping PR creation as commit does not originate from promotion PR", nil
 	}
@@ -63,7 +65,7 @@ func promote(ctx context.Context, cfg config.Config, repo *git.Repository, state
 	if err != nil {
 		return "", fmt.Errorf("could not create branch: %w", err)
 	}
-	_, err = repo.CreateCommit(state.BranchName(), state.Title())
+	sha, err := repo.CreateCommit(state.BranchName(), state.Title())
 	if err != nil {
 		return "", fmt.Errorf("could not commit changes: %w", err)
 	}
@@ -79,7 +81,7 @@ func promote(ctx context.Context, cfg config.Config, repo *git.Repository, state
 	if err != nil {
 		return "", fmt.Errorf("could not create a PR: %w", err)
 	}
-	return fmt.Sprintf("created branch %s with pull request %d", state.BranchName(), prid), nil
+	return fmt.Sprintf("created branch %s with pull request %d on commit %s", state.BranchName(), prid, sha), nil
 }
 
 func updateImageTag(path, app, group, tag string) error {

--- a/pkg/command/promote.go
+++ b/pkg/command/promote.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/fluxcd/image-automation-controller/pkg/update"
 	imagev1alpha1_reflect "github.com/fluxcd/image-reflector-controller/api/v1alpha1"
@@ -94,6 +95,7 @@ func updateImageTag(path, app, group, tag string) error {
 		},
 	}
 
+	log.Printf("Updating images with %s:%s:%s in %s\n", group, app, tag, path)
 	_, err := update.UpdateWithSetters(path, path, policies)
 	if err != nil {
 		return fmt.Errorf("failed updating manifests: %w", err)

--- a/pkg/command/promote.go
+++ b/pkg/command/promote.go
@@ -75,11 +75,11 @@ func promote(ctx context.Context, cfg config.Config, repo *git.Repository, state
 	if err != nil {
 		return "", fmt.Errorf("could not get environment automation state: %w", err)
 	}
-	err = repo.CreatePR(ctx, state.BranchName(), auto, state)
+	prid, err := repo.CreatePR(ctx, state.BranchName(), auto, state)
 	if err != nil {
 		return "", fmt.Errorf("could not create a PR: %w", err)
 	}
-	return "created promotions pull request", nil
+	return fmt.Sprintf("created branch %s with pull request %d", state.BranchName(), prid), nil
 }
 
 func updateImageTag(path, app, group, tag string) error {

--- a/pkg/command/promote.go
+++ b/pkg/command/promote.go
@@ -23,6 +23,7 @@ func PromoteCommand(ctx context.Context, providerType string, path, token string
 	}
 	pr, err := repo.GetPRThatCausedCurrentCommit(ctx)
 	if err != nil {
+		//nolint:errcheck //best effort for logging
 		sha, _ := repo.GetCurrentCommit()
 		log.Printf("Failed retrieving pull request for commit %s: %v", sha, err)
 		//lint:ignore nilerr should not return error

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 	"time"
@@ -104,6 +105,9 @@ func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto 
 			GitPullRequestToUpdate: &updatePR,
 		}
 		_, err = g.client.UpdatePullRequest(ctx, updateArgs)
+		if err == nil {
+			log.Printf("Updated PR #%d merging %s -> %s\n", *pr.PullRequestId, sourceRefName, targetRefName)
+		}
 		return err
 	}
 
@@ -126,6 +130,7 @@ func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto 
 	if err != nil {
 		return err
 	}
+	log.Printf("Created new PR #%d merging %s -> %s\n", *pr.PullRequestId, sourceRefName, targetRefName)
 	if !auto {
 		return nil
 	}
@@ -143,6 +148,9 @@ func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto 
 		GitPullRequestToUpdate: &updatePR,
 	}
 	_, err = g.client.UpdatePullRequest(ctx, updateArgs)
+	if err == nil {
+		log.Printf("Auto-merge activated for PR #%d\n", *pr.PullRequestId)
+	}
 	return err
 }
 

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -68,13 +68,13 @@ func NewAzdoGITProvider(ctx context.Context, remoteURL, token string) (*AzdoGITP
 }
 
 // CreatePR ...
-func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) error {
+func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) (int, error) {
 	sourceRefName := fmt.Sprintf("refs/heads/%s", branchName)
 	targetRefName := fmt.Sprintf("refs/heads/%s", DefaultBranch)
 	title := state.Title()
 	description, err := state.Description()
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// Update PR if it already exists
@@ -108,7 +108,7 @@ func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto 
 		if err == nil {
 			log.Printf("Updated PR #%d merging %s -> %s\n", *pr.PullRequestId, sourceRefName, targetRefName)
 		}
-		return err
+		return *pr.PullRequestId, err
 	}
 
 	// Create new PR
@@ -128,11 +128,11 @@ func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto 
 	}
 	pr, err := g.client.CreatePullRequest(ctx, createArgs)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	log.Printf("Created new PR #%d merging %s -> %s\n", *pr.PullRequestId, sourceRefName, targetRefName)
 	if !auto {
-		return nil
+		return *pr.PullRequestId, nil
 	}
 
 	// This update is done to set auto merge. The reason this is not
@@ -151,7 +151,7 @@ func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto 
 	if err == nil {
 		log.Printf("Auto-merge activated for PR #%d\n", *pr.PullRequestId)
 	}
-	return err
+	return *pr.PullRequestId, err
 }
 
 func (g *AzdoGITProvider) GetStatus(ctx context.Context, sha string, group string, env string) (Status, error) {

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -68,6 +68,7 @@ func NewAzdoGITProvider(ctx context.Context, remoteURL, token string) (*AzdoGITP
 }
 
 // CreatePR ...
+//nolint:funlen // temporary
 func (g *AzdoGITProvider) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) (int, error) {
 	sourceRefName := fmt.Sprintf("refs/heads/%s", branchName)
 	targetRefName := fmt.Sprintf("refs/heads/%s", DefaultBranch)

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -65,6 +65,7 @@ func NewGitHubGITProvider(ctx context.Context, remoteURL, token string) (*GitHub
 }
 
 // CreatePR ...
+//nolint:gocognit //temporary
 func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) (int, error) {
 	sourceName := branchName
 	targetName := DefaultBranch

--- a/pkg/git/provider.go
+++ b/pkg/git/provider.go
@@ -16,7 +16,7 @@ const (
 type GitProvider interface {
 	GetStatus(ctx context.Context, sha, group, env string) (Status, error)
 	SetStatus(ctx context.Context, sha string, group string, env string, succeeded bool) error
-	CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) error
+	CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) (int, error)
 	GetPRWithBranch(ctx context.Context, source, target string) (PullRequest, error)
 	GetPRThatCausedCommit(ctx context.Context, sha string) (PullRequest, error)
 	MergePR(ctx context.Context, ID int, sha string) error

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"log"
 	"path/filepath"
 	"time"
 
@@ -131,10 +132,12 @@ func (g *Repository) CreateCommit(branchName, message string) (*git2go.Oid, erro
 	if err != nil {
 		return nil, err
 	}
-	sha, err := g.gitRepository.CreateCommit(fmt.Sprintf("refs/heads/%s", branchName), signature, signature, message, tree, commitTarget)
+	refName := fmt.Sprintf("refs/heads/%s", branchName)
+	sha, err := g.gitRepository.CreateCommit(refName, signature, signature, message, tree, commitTarget)
 	if err != nil {
 		return nil, err
 	}
+	log.Printf("Created commit %s on %s with message '%s'\n", sha, refName, message)
 
 	return sha, nil
 }
@@ -166,6 +169,7 @@ func (g *Repository) Push(branchName string, force bool) error {
 	if err != nil {
 		return fmt.Errorf("failed pushing branches %s: %w", branches, err)
 	}
+	log.Printf("Pushed branch %s to remote\n", branches[0])
 	return nil
 }
 

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -173,7 +173,7 @@ func (g *Repository) Push(branchName string, force bool) error {
 	return nil
 }
 
-func (g *Repository) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) error {
+func (g *Repository) CreatePR(ctx context.Context, branchName string, auto bool, state *PRState) (int, error) {
 	return g.gitProvider.CreatePR(ctx, branchName, auto, state)
 }
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -97,7 +97,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Contains(t, newCommandMsgDev, "created promotions pull request")
+			require.Contains(t, newCommandMsgDev, fmt.Sprintf("created branch %s with pull request", promoteBranchName))
 
 			path = testCloneRepositoryAndValidateTag(t, p.url, p.username, p.password, p.defaultBranch, group, "dev", app, tag)
 
@@ -116,7 +116,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Contains(t, promoteCommandMsgQa, "created promotions pull request")
+			require.Contains(t, promoteCommandMsgQa, fmt.Sprintf("created branch %s with pull request", promoteBranchName))
 
 			path = testCloneRepositoryAndValidateTag(t, p.url, p.username, p.password, promoteBranchName, group, "qa", app, tag)
 			statusCommandMsgQa, err := testRunCommand(
@@ -152,7 +152,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Contains(t, promoteCommandMsgProd, "created promotions pull request")
+			require.Contains(t, promoteCommandMsgProd, fmt.Sprintf("created branch %s with pull request", promoteBranchName))
 
 			path = testCloneRepositoryAndValidateTag(t, p.url, p.username, p.password, promoteBranchName, group, "prod", app, tag)
 			statusCommandMsgProd, err := testRunCommand(

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -97,7 +97,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Equal(t, "created promotions pull request", newCommandMsgDev)
+			require.Contains(t, newCommandMsgDev, "created promotions pull request")
 
 			path = testCloneRepositoryAndValidateTag(t, p.url, p.username, p.password, p.defaultBranch, group, "dev", app, tag)
 
@@ -116,7 +116,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Equal(t, "created promotions pull request", promoteCommandMsgQa)
+			require.Contains(t, promoteCommandMsgQa, "created promotions pull request")
 
 			path = testCloneRepositoryAndValidateTag(t, p.url, p.username, p.password, promoteBranchName, group, "qa", app, tag)
 			statusCommandMsgQa, err := testRunCommand(
@@ -128,7 +128,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Equal(t, "status check has succeed", statusCommandMsgQa)
+			require.Contains(t, statusCommandMsgQa, "status check has succeed")
 
 			repoQa := testGetRepository(t, path)
 			revQa := testGetRepositoryHeadRevision(t, repoQa)
@@ -152,7 +152,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Equal(t, "created promotions pull request", promoteCommandMsgProd)
+			require.Contains(t, promoteCommandMsgProd, "created promotions pull request")
 
 			path = testCloneRepositoryAndValidateTag(t, p.url, p.username, p.password, promoteBranchName, group, "prod", app, tag)
 			statusCommandMsgProd, err := testRunCommand(
@@ -164,7 +164,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Equal(t, "status check has succeed", statusCommandMsgProd)
+			require.Contains(t, statusCommandMsgProd, "status check has succeed")
 
 			repoProd := testGetRepository(t, path)
 			revProd := testGetRepositoryHeadRevision(t, repoProd)


### PR DESCRIPTION
gitops-promotion is written in the style of a cli tool. As such, it should not spam unnecessarily. However, when running in a pipeline you sometimes want to look at old runs where it is not always obvious e.g. what commits were actually visible at the time, we need some logging. This PR introduces a bit of daemon-style logging in the hope that issues can be debugged more easily. It also improves on the central messages from new and promote commands to say what PR was created and what its branch is called. This is generally useful, but is particularly pertinent if we merge #136 which may create more than one PR which differ only in the container sha.