### PR TITLE
GitHub provider fails if no auto-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,22 @@ Support for Azure DevOps is mature, but alas the documentation is not. TBD.
 
 ## Using with Github
 
+gitops-promotion has full support for GitHub.
+
+### Required repository configuration
+
+gitops-promotion makes use of [PR auto-merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request). This requires specific configuration:
+
+1. In repository settings, turn on "Allow auto-merge"
+1. Set up a branch protection rule for your "main" branch:
+  - "Require a pull request before merging"
+  - "Require status checks to pass"
+  - Add the workflow for the `status` commend to "Status checks that are required". In the example below, you would enter "prev-env-status". Bizarrely, the UI will not allow you to enter the name, so you may have to trigger a run once so you can use the search interface.
+
+You can verify that your settings are correct by manually creating a pull request and verify that the button says "Enable auto-merge".
+
+### Configuring your workflow
+
 gitops-promotion is available as a Github Action.
 
 Depending on which container registry you are using, you may be able to set up triggers that activates your gitops-promotion workflow. If this is not the case, you can use GitHub [repository_dispatch](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#repository_dispatch) events. These allow GitHub actions on one repository to notify another repository. Use the excellent [repository-dispatch GitHub Action](https://github.com/marketplace/actions/repository-dispatch) for readable YAML. You would add a step at the end of your container-building workflow that looks something like this:
@@ -298,6 +314,12 @@ jobs:
           action: status
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+Please note that you will need to make this a required check for merging into main, so it is important that it runs on all pull requests against "main" or your manual pull requests will not be mergeable.
+
+## Troubleshooting
+
+**GitHub PR creation says "could not set auto-merge on PR"**: Your repository is not properly configured to allow pull request auto-merge. Pleae see the configuration section above for information on how to do this.
 
 ## Building
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-openapi/validate v0.20.2 // indirect
 	github.com/google/go-containerregistry v0.5.0 // indirect
-	github.com/google/go-github/v37 v37.0.0
+	github.com/google/go-github/v40 v40.0.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/jfrog/jfrog-client-go v0.26.1

--- a/go.sum
+++ b/go.sum
@@ -648,10 +648,11 @@ github.com/google/go-containerregistry v0.1.1/go.mod h1:npTSyywOeILcgWqd+rvtzGWf
 github.com/google/go-containerregistry v0.5.0 h1:eb9sinv4PKm0AUwQGov0mvIdA4pyBGjRofxN4tWnMwM=
 github.com/google/go-containerregistry v0.5.0/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
-github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
-github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-github/v40 v40.0.0 h1:oBPVDaIhdUmwDWRRH8XJ/dZG+Rn755i08+Hp1uJHlR0=
+github.com/google/go-github/v40 v40.0.0/go.mod h1:G8wWKTEjUCL0zdbaQvpwDk0hqf6KZgPQH+ssJa+/NVc=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/go-replayers/grpcreplay v0.1.0/go.mod h1:8Ig2Idjpr6gifRd6pNVggX6TC1Zw6Jx74AKp7QNH2QE=
 github.com/google/go-replayers/httpreplay v0.1.0/go.mod h1:YKZViNhiGgqdBlUbI2MwGpq4pXxNmhJLPHQ7cv2b5no=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
@@ -1341,8 +1342,9 @@ golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 h1:HWj/xjIHfjYU5nVXpTM0s39J9CbLn7Cc5a7IC5rwsMQ=
+golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -22,7 +22,7 @@ type AzdoGITProvider struct {
 
 // NewAdoGITProvider ...
 func NewAzdoGITProvider(ctx context.Context, remoteURL, token string) (*AzdoGITProvider, error) {
-	host, id, err := parseGitAddress(remoteURL)
+	host, id, err := ParseGitAddress(remoteURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go"
-	"github.com/google/go-github/v37/github"
+	"github.com/google/go-github/v40/github"
 	"github.com/shurcooL/githubv4"
 	"golang.org/x/oauth2"
 )
@@ -141,8 +141,7 @@ func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, aut
 		} else {
 			log.Printf("Failed to activate auto-merge for PR %d: %v", pr.GetNumber(), err)
 			if strings.Contains(err.Error(), "not in the correct state") {
-				err = g.MergePR(ctx, int(pr.GetNumber()), *pr.GetHead().SHA)
-				log.Printf("Explicitly merged PR #%d\n", pr.GetNumber())
+				err = fmt.Errorf("could not set auto-merge on PR #%d (check auto-merge setting and required checks)", pr.GetNumber())
 			}
 		}
 	}

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -34,7 +34,7 @@ func NewGitHubGITProvider(ctx context.Context, remoteURL, token string) (*GitHub
 		return nil, fmt.Errorf("token empty")
 	}
 
-	host, id, err := parseGitAddress(remoteURL)
+	host, id, err := ParseGitAddress(remoteURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v37/github"
+	"github.com/google/go-github/v40/github"
 	"github.com/google/uuid"
 	git2go "github.com/libgit2/git2go/v31"
 	. "github.com/onsi/ginkgo"

--- a/pkg/git/github_test.go
+++ b/pkg/git/github_test.go
@@ -235,10 +235,8 @@ var _ = Describe("GitHubGITProvider CreatePR", func() {
 			pushBranch(repo, branchName)
 		})
 
-		It("merges the PR directly", func() {
-			Expect(err).To(BeNil())
-			_, e := provider.GetPRWithBranch(ctx, branchName, DefaultBranch)
-			Expect(e.Error()).To(ContainSubstring("no PR found"))
+		It("returns an error saying auto-merge is not turned on", func() {
+			Expect(err.Error()).To(ContainSubstring("could not set auto-merge"))
 		})
 
 		When("and the repository has branch protection requiring passing statuses", func() {

--- a/pkg/git/util.go
+++ b/pkg/git/util.go
@@ -7,7 +7,8 @@ import (
 	giturls "github.com/whilp/git-urls"
 )
 
-func parseGitAddress(s string) (string, string, error) {
+// ParseGitAddress ...
+func ParseGitAddress(s string) (host string, id string, err error) {
 	u, err := giturls.Parse(s)
 	if err != nil {
 		return "", "", err
@@ -18,8 +19,8 @@ func parseGitAddress(s string) (string, string, error) {
 		scheme = "https"
 	}
 
-	id := strings.TrimLeft(u.Path, "/")
+	id = strings.TrimLeft(u.Path, "/")
 	id = strings.TrimSuffix(id, ".git")
-	host := fmt.Sprintf("%s://%s", scheme, u.Host)
+	host = fmt.Sprintf("%s://%s", scheme, u.Host)
 	return host, id, nil
 }

--- a/pkg/git/util_test.go
+++ b/pkg/git/util_test.go
@@ -46,7 +46,7 @@ func TestParseGitAddress(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		host, id, err := parseGitAddress(c.input)
+		host, id, err := ParseGitAddress(c.input)
 		if c.expectedError != "" {
 			require.EqualError(t, err, c.expectedError)
 		}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -9,9 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-github/v40/github"
 	"github.com/stretchr/testify/require"
 	"github.com/xenitab/gitops-promotion/pkg/command"
 	"github.com/xenitab/gitops-promotion/pkg/git"
+	"golang.org/x/oauth2"
 )
 
 type providerConfig struct {
@@ -20,6 +22,14 @@ type providerConfig struct {
 	password      string
 	url           string
 	defaultBranch string
+	setup         func(ctx context.Context, config *providerConfig) error
+	teardown      func(ctx context.Context, config *providerConfig) error
+}
+
+func makeGitHubClient(ctx context.Context, config *providerConfig) *github.Client {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: config.password})
+	tc := oauth2.NewClient(ctx, ts)
+	return github.NewClient(tc)
 }
 
 var providers = []providerConfig{
@@ -29,6 +39,8 @@ var providers = []providerConfig{
 		password:      os.Getenv("AZDO_PAT"),
 		url:           os.Getenv("AZDO_URL"),
 		defaultBranch: "main",
+		setup:         func(ctx context.Context, config *providerConfig) error { return nil },
+		teardown:      func(ctx context.Context, config *providerConfig) error { return nil },
 	},
 	{
 		providerType:  "github",
@@ -36,6 +48,46 @@ var providers = []providerConfig{
 		password:      os.Getenv("GITHUB_TOKEN"),
 		url:           os.Getenv("GITHUB_URL"),
 		defaultBranch: "main",
+		setup: func(ctx context.Context, config *providerConfig) error {
+			client := makeGitHubClient(ctx, config)
+			_, id, err := git.ParseGitAddress(config.url)
+			if err != nil {
+				return err
+			}
+			comp := strings.Split(id, "/")
+			owner := comp[0]
+			repo := comp[1]
+			_, _, err = client.Repositories.UpdateBranchProtection(
+				ctx,
+				owner,
+				repo,
+				config.defaultBranch,
+				&github.ProtectionRequest{
+					EnforceAdmins: true,
+					RequiredStatusChecks: &github.RequiredStatusChecks{
+						Strict:   true,
+						Contexts: []string{},
+					},
+				})
+			return err
+		},
+		teardown: func(ctx context.Context, config *providerConfig) error {
+			client := makeGitHubClient(ctx, config)
+			_, id, err := git.ParseGitAddress(config.url)
+			if err != nil {
+				return err
+			}
+			comp := strings.Split(id, "/")
+			owner := comp[0]
+			repo := comp[1]
+			_, _, err = client.Repositories.UpdateBranchProtection(
+				ctx,
+				owner,
+				repo,
+				config.defaultBranch,
+				&github.ProtectionRequest{})
+			return err
+		},
 	},
 }
 
@@ -65,6 +117,10 @@ func testRunCommand(t *testing.T, path string, verb string, args ...string) (str
 
 func TestProviderE2E(t *testing.T) {
 	for _, p := range providers {
+		ctx := context.Background()
+		//nolint:gosec // I'm calling it on p...
+		err := p.setup(ctx, &p)
+		require.NoError(t, err)
 		t.Run(p.providerType, func(t *testing.T) {
 			if p.url == "" || p.password == "" {
 				t.Skipf("Skipping test since url or password env var is not set")
@@ -178,5 +234,8 @@ func TestProviderE2E(t *testing.T) {
 
 			testSetStatus(t, ctx, providerType, revMergedProd, group, "prod", p.url, p.password, true)
 		})
+		//nolint:gosec // I'm calling it on p...
+		err = p.teardown(ctx, &p)
+		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
Previous implementation merged the PR immediately if the call to enable PR auto-merge failed. However, this is problematic because the merge is used to trigger propagation to the next environment, so immediate merge will sidestep the Flux reconciliation check. If we have been asked `auto: true` for an environment, it is reasonable to require the repo to be correctly configured and just fail if it is not; there is no good way to later explicitly merge the PR (you would have to have a specific scheduled task or similar). The PR includes docs to explain what the correct configuration is.

Apart from removing the one offending line, this PR also ensures that the e2e tests operate under the correct circumstances, just as the provider-level tests do, setting branch protection.

The switch from go-githhub v37 to v40 was done because one iteration of this PR had a repo level check on the auto-merge setting. It is strictly speaking no longer necessary, but I kept it because I thought it was a useful change (and somewhat hard to extricate into a separate PR). Since we have extensive integration tests on the GitHub provider, I think the risk of new issues is small.