### PR TITLE
Remove source-controller dependency which is unnecessary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/fluxcd/image-automation-controller v0.14.1
 	github.com/fluxcd/image-reflector-controller/api v0.15.0
-	github.com/fluxcd/source-controller v0.15.4
 	github.com/google/go-github/v40 v40.0.0
 	github.com/google/uuid v1.3.0
 	github.com/jfrog/jfrog-client-go v1.7.1


### PR DESCRIPTION
It would seem we used source-controller only as a holder for the remote auth callback. This PR replaces the `Auth` struct (which is no longer in source-controller) with the standard git2go `RemoteCallbacks` struct which we anyway use in the actual git2go method calls for `Clone` and `Push`.