### PR TITLE
Clarify status command output

### DIFF
--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -46,14 +46,14 @@ func StatusCommand(ctx context.Context, cfg config.Config, repo *git.Repository)
 
 		status, err := repo.GetStatus(ctx, pr.State.Sha, pr.State.Group, prevEnv.Name)
 		if err != nil {
-			fmt.Printf("retrying status check: %v\n", err)
+			fmt.Printf("retrying status check for %s-%s: %v\n", pr.State.Group, prevEnv.Name, err)
 			time.Sleep(5 * time.Second)
 			continue
 		}
 		if !status.Succeeded {
-			return "", fmt.Errorf("commit status check has failed %q", pr.State.Sha)
+			return "", fmt.Errorf("commit status check for %s-%s has failed %q", pr.State.Group, prevEnv.Name, pr.State.Sha)
 		}
 		return "status check has succeed", nil
 	}
-	return "", fmt.Errorf("commit status check has timed out %q", pr.State.Sha)
+	return "", fmt.Errorf("commit status check for %s-%s has timed out %q", pr.State.Group, prevEnv.Name, pr.State.Sha)
 }

--- a/pkg/git/azdo.go
+++ b/pkg/git/azdo.go
@@ -165,6 +165,13 @@ func (g *AzdoGITProvider) GetStatus(ctx context.Context, sha string, group strin
 	if err != nil {
 		return CommitStatus{}, err
 	}
+	var displays = make([]string, len(*statuses))
+	for i := range *statuses {
+		s := (*statuses)[i]
+		displays = append(displays, fmt.Sprintf("%s/%s: %s (%s)", *s.Context.Genre, *s.Context.Name, *s.State, *s.Description))
+	}
+	log.Printf("Considering statuses %v\n", displays)
+
 	genre := "fluxcd"
 	name := fmt.Sprintf("%s-%s", group, env)
 	for i := range *statuses {

--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -150,7 +150,12 @@ func (g *GitHubGITProvider) GetStatus(ctx context.Context, sha string, group str
 	if err != nil {
 		return CommitStatus{}, err
 	}
-	log.Printf("Considering statuses %v\n", statuses)
+	var displays = make([]string, len(statuses))
+	for i := range statuses {
+		s := statuses[i]
+		displays = append(displays, fmt.Sprintf("%s: %s (%s)", *s.Context, *s.State, *s.Description))
+	}
+	log.Printf("Considering statuses %v\n", displays)
 
 	name := fmt.Sprintf("%s-%s", group, env)
 	for _, s := range statuses {


### PR DESCRIPTION
The status command is the only command that users actually look at and also the one which has the potential to be confusing.

This PR improves its logging, which is also presented as output in the GitHub workflow. In particular, it now prints the name of the environment whose status we are looking for. This particularly relevant in GitHub, since the runs title is borrowed from the PR and may change post-fact, causing very confusing situations. Also, it cleans up the candidate logging which has proved useful to see what statuses were available at the time of the command; Flux may add statuses after the command has given up looking for them.

Fixes #164 .