### PR TITLE
Status command checks main branch too

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ The `status` command requests statuses on the merge commit that resulted from th
 
 ![Kustomization checks](./assets/kustomization-checks.png)
 
-It keeps looking for that status for some time. If it remains failed after some minutes, the `status` command fails, resulting in a failed check on the pull request, blocking any automatic merging.
+If there is no matching status, it then looks on the head commit of "main" branch. If another commit is added to main before Flux has time to consider the merge commit, the merge commit status will never be set, but a relevant status will eventually be set on "main" branch.
+
+The `status` command keeps looking for statuses for some time. If there is no status after some minutes, the `status` command fails, resulting in a failed check on the pull request, blocking any automatic merging.
 
 ## The GitOps repository
 

--- a/README.md
+++ b/README.md
@@ -355,3 +355,23 @@ The test suite for the GitHub provider requires access to an actual GitHub repos
 env GITHUB_URL='' GITHUB_TOKEN='' go test ./...
 
 The GitHub Action CI runs the tests against [https://github.com/gitops-promotion/gitops-promotion-testing](https://github.com/gitops-promotion/gitops-promotion-testing).
+
+In order to test interactions manually, you may want to trigger a new promotion. Assuming you are using the example above based on repository-dispatch, the following command will inject a new event:
+
+```shell
+curl -X POST \
+  -H "Authorization: token <PAT>" \
+  -H "Accept: application/vnd.github.v3+json" \
+  -d '{"event_type": "image-push", "client_payload": {"group": "apps", "app": "my-app", "tag": "123456"}}' \
+  https://api.github.com/repos/<org>/<repo>/dispatches
+```
+
+In order to emulate a status update from Flux, use the following command:
+
+```shell
+curl -X POST \
+  -H "Authorization: token <PAT>" \
+  -H "Accept: application/vnd.github.v3+json" \
+  -d '{"state": "success", "context": "kustomization/apps-qa", "description": "reconciliation succeeded"}' \
+  https://api.github.com/repos/<org>/<repo>/commits/<sha>/statuses
+```

--- a/action.yaml
+++ b/action.yaml
@@ -22,7 +22,7 @@ inputs:
     requires: false
 runs:
   using: docker
-  image: docker://ghcr.io/xenitab/gitops-promotion:v1.0.0-pre2
+  image: docker://ghcr.io/xenitab/gitops-promotion:status-on-main
   entrypoint: /usr/local/bin/action-entrypoint.sh
   env:
     ACTION: ${{ inputs.action }}

--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -38,7 +38,7 @@ func StatusCommand(ctx context.Context, cfg config.Config, repo *git.Repository)
 		return "", err
 	}
 	// TODO: Check if current commit is stale
-	deadline := time.Now().Add(5 * time.Minute)
+	deadline := time.Now().Add(cfg.StatusTimeout)
 	for {
 		if time.Now().After(deadline) {
 			break

--- a/pkg/command/status.go
+++ b/pkg/command/status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/xenitab/gitops-promotion/pkg/git"
 )
 
+//nolint:gocognit // not convinced that extracting bits would make it more readable
 // StatusCommand is run inside a PR to check if the PR can be merged.
 func StatusCommand(ctx context.Context, cfg config.Config, repo *git.Repository) (string, error) {
 	// If branch does not contain promote it was manual, return early
@@ -37,23 +38,31 @@ func StatusCommand(ctx context.Context, cfg config.Config, repo *git.Repository)
 	if err != nil {
 		return "", err
 	}
-	// TODO: Check if current commit is stale
 	deadline := time.Now().Add(cfg.StatusTimeout)
 	for {
 		if time.Now().After(deadline) {
 			break
 		}
-
 		status, err := repo.GetStatus(ctx, pr.State.Sha, pr.State.Group, prevEnv.Name)
+		if err == nil {
+			if !status.Succeeded {
+				return "", fmt.Errorf("failed reconciliation for %s-%s found on %q", pr.State.Group, prevEnv.Name, pr.State.Sha)
+			}
+			return fmt.Sprintf("successful reconciliation for %s-%s found on %q", pr.State.Group, prevEnv.Name, pr.State.Sha), nil
+		}
+		head, err := repo.FetchBranch(git.DefaultBranch)
 		if err != nil {
-			fmt.Printf("retrying status check for %s-%s: %v\n", pr.State.Group, prevEnv.Name, err)
-			time.Sleep(5 * time.Second)
-			continue
+			return "", fmt.Errorf("failed to fetch new commits: %w", err)
 		}
-		if !status.Succeeded {
-			return "", fmt.Errorf("commit status check for %s-%s has failed %q", pr.State.Group, prevEnv.Name, pr.State.Sha)
+		status, err = repo.GetStatus(ctx, head.String(), pr.State.Group, prevEnv.Name)
+		if err == nil {
+			if !status.Succeeded {
+				return "", fmt.Errorf("failed reconciliation for %s-%s found on %s at %s", pr.State.Group, prevEnv.Name, git.DefaultBranch, head)
+			}
+			return fmt.Sprintf("successful reconciliation for %s-%s found on %s at %s", pr.State.Group, prevEnv.Name, git.DefaultBranch, head), nil
 		}
-		return "status check has succeed", nil
+		fmt.Printf("retrying status check for %s-%s: %v\n", pr.State.Group, prevEnv.Name, err)
+		time.Sleep(5 * time.Second)
 	}
 	return "", fmt.Errorf("commit status check for %s-%s has timed out %q", pr.State.Group, prevEnv.Name, pr.State.Sha)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,13 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"time"
 
 	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
-	PRFlow       string        `yaml:"prflow"`
-	Environments []Environment `yaml:"environments"`
+	PRFlow        string        `yaml:"prflow"`
+	StatusTimeout time.Duration `yaml:"status_timeout_minutes"`
+	Environments  []Environment `yaml:"environments"`
 }
 
 type Environment struct {
@@ -29,6 +31,9 @@ func LoadConfig(file io.Reader) (Config, error) {
 		cfg.PRFlow = "per-app"
 	} else if cfg.PRFlow != "per-app" && cfg.PRFlow != "per-env" {
 		return Config{}, fmt.Errorf("invalid prflow value %s", cfg.PRFlow)
+	}
+	if cfg.StatusTimeout.String() == (0 * time.Minute).String() {
+		cfg.StatusTimeout = 5 * time.Minute
 	}
 	return cfg, err
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -62,6 +63,16 @@ var _ = Describe("Config", func() {
 			It("throws an error", func() {
 				Expect(err).NotTo(BeNil())
 			})
+		})
+	})
+
+	Describe("Looking at status_timeout", func() {
+		BeforeEach(func() {
+			configData = environmentList
+		})
+
+		It("defaults to 5 minutes", func() {
+			Expect(config.StatusTimeout).To(Equal(5 * time.Minute))
 		})
 	})
 })

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -191,7 +191,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Contains(t, statusCommandMsgQa, "status check has succeed")
+			require.Contains(t, statusCommandMsgQa, "successful reconciliation for testgroup-dev")
 
 			repoQa := testGetRepository(t, path)
 			revQa := testGetRepositoryHeadRevision(t, repoQa)
@@ -228,7 +228,7 @@ func TestProviderE2E(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			require.Contains(t, statusCommandMsgProd, "status check has succeed")
+			require.Contains(t, statusCommandMsgProd, "successful reconciliation for testgroup-qa")
 
 			repoProd := testGetRepository(t, path)
 			revProd := testGetRepositoryHeadRevision(t, repoProd)


### PR DESCRIPTION
A commit may be added to "main" branch after a promotion merge commit, but before Flux had a chance to reconcile the merge commit. In this case, Flux will never reconcile the merge commit, and the status command will eventually time out with failure. This PR has the status command also consider statuses from head on "main" branch, since Flux will eventually get around to reconcile head.

Note that this PR does not address the (probably more common) case where the merge commit has a failed status which has since been fixed on main.

Fixes #175 .