### PR TITLE
Update to new error message from GitHub

### DIFF
--- a/pkg/git/github.go
+++ b/pkg/git/github.go
@@ -136,7 +136,7 @@ func (g *GitHubGITProvider) CreatePR(ctx context.Context, branchName string, aut
 			log.Printf("Auto-merge activated for PR #%d\n", pr.GetNumber())
 		} else {
 			log.Printf("Failed to activate auto-merge for PR %d: %v", pr.GetNumber(), err)
-			if strings.Contains(err.Error(), "not in the correct state") {
+			if strings.Contains(err.Error(), "Can't enable auto-merge") {
 				err = fmt.Errorf("could not set auto-merge on PR #%d (check auto-merge setting and required checks)", pr.GetNumber())
 			}
 		}


### PR DESCRIPTION
We saw an issue after merging the latest changes, presumably GitHub has updated their error message:
```
 GitHubGITProvider CreatePR
/home/runner/work/gitops-promotion/gitops-promotion/pkg/git/github_test.go:122
  when Creating/updating a PR with automerge
  /home/runner/work/gitops-promotion/gitops-promotion/pkg/git/github_test.go:227
    returns an error saying auto-merge is not turned on [It]
    /home/runner/work/gitops-promotion/gitops-promotion/pkg/git/github_test.go:238

    Expected
        <string>: Can't enable auto-merge for this pull request.
    to contain substring
        <string>: could not set auto-merge

    /home/runner/work/gitops-promotion/gitops-promotion/pkg/git/github_test.go:239
```