### PR TITLE
Add option to overwrite application instead of duplicating it

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Usage of feature:
         Access token (PAT) to git provider
 ```
 
-The `feature` command is used to create temporary deployments of applications. Instead of updating the existing application image tag a new copy of all of the applications manifests will be created instead.
+The `feature` command is used to create temporary deployments of applications. It can either overwrite an existing applications image tag, or it can create a new copy of all of the applications manifests. This behavior depends on if `featureOverwrite` is enabled or not. Either way a feature will never be promoted.
 
 ## The GitOps repository
 
@@ -183,6 +183,7 @@ groups:
   apps:
     applications:
       podinfo:
+        featureOverwrite: false
         featureLabelSelector:
           app: podinfo
 ```

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,6 +16,7 @@ const (
 )
 
 type App struct {
+	FeatureOverwrite     bool              `yaml:"featureOverwrite"`
 	FeatureLabelSelector map[string]string `yaml:"featureLabelSelector"`
 }
 
@@ -104,6 +105,18 @@ func (c Config) IsAnyEnvironmentManual() bool {
 		}
 	}
 	return false
+}
+
+func (c Config) HasFeatureOverwrite(group, app string) (bool, error) {
+	groupObj, ok := c.Groups[group]
+	if !ok {
+		return false, fmt.Errorf("configuration does not contain group %s", group)
+	}
+	appObj, ok := groupObj.Applications[app]
+	if !ok {
+		return false, fmt.Errorf("configuration for group %s does not contain application %s", group, app)
+	}
+	return appObj.FeatureOverwrite, nil
 }
 
 func (c Config) GetFeatureLabelSelector(group, app string) (map[string]string, error) {


### PR DESCRIPTION
This PR adds a new feature which allows feature branches to overwrite the existing application instead of creating a duplicate version of the application.